### PR TITLE
chore: gitignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ $RECYCLE.BIN/
 
 # Claude Code local state
 .claude/
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Ignore the project-level `CLAUDE.md` (Claude Code's per-repo guide) so it stays a local artifact, alongside the existing `.claude/` entry.
- `Cargo.toml`'s `exclude` already keeps `CLAUDE.md` out of published crate tarballs; this closes the gap on the git side.

## Test plan
- [x] `git check-ignore -v CLAUDE.md` resolves to the new rule
- [x] `git status` no longer reports `CLAUDE.md` as untracked