### PR TITLE
Code review batch: redis correctness, postgres JSON-paths, scheduler atomicity, dashboard shutdown, error chains, CAS, list typing

### DIFF
--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -130,12 +130,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create sample jobs
     create_sample_jobs(Arc::clone(&storage)).await?;
 
-    // Create and start dashboard server
+    // Create and start dashboard server. `..Default::default()` keeps the
+    // example resilient to additive fields on `DashboardConfig` — e.g. the
+    // `metrics` field gated on the `metrics` feature would otherwise force
+    // an `#[cfg(feature = "metrics")]` arm here.
     let dashboard_config = DashboardConfig {
         host: "127.0.0.1".to_string(),
         port: 8080,
         statistics_update_interval: 3, // Update every 3 seconds for demo
         auth: None,
+        ..Default::default()
     };
 
     let dashboard = DashboardServer::new(storage.clone(), dashboard_config);

--- a/examples/storage_demo.rs
+++ b/examples/storage_demo.rs
@@ -162,8 +162,9 @@ async fn demo_storage_operations(
     println!("     ✓ Found {} jobs total", all_jobs.len());
 
     // List jobs by state
-    let enqueued_state = JobState::enqueued("default");
-    let enqueued_jobs = storage.list(Some(&enqueued_state), None, None).await?;
+    let enqueued_jobs = storage
+        .list(Some(JobStateKind::Enqueued), None, None)
+        .await?;
     println!("     ✓ Found {} enqueued jobs", enqueued_jobs.len());
 
     // Get job counts

--- a/src/dashboard/routes.rs
+++ b/src/dashboard/routes.rs
@@ -8,7 +8,6 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::core::JobState;
 use crate::dashboard::service::{
     DashboardService, JobDetails, JobStatistics, QueueStatistics, ServerStatistics,
 };
@@ -233,19 +232,21 @@ async fn health_check() -> Json<ApiResponse<&'static str>> {
     Json(ApiResponse::success("Dashboard service is running"))
 }
 
-/// Helper function to parse job state from string
-fn parse_job_state(state_str: &str) -> Option<JobState> {
-    // For filtering purposes, create dummy states with minimal data
+/// Parse a job state filter string from the URL query into the typed
+/// [`JobStateKind`] discriminant. Returning `JobStateKind` (rather than
+/// constructing a throwaway `JobState` with bogus inner fields just to
+/// pick a variant) keeps the discarded data discardable at the type
+/// level — `Storage::list` only ever filtered by discriminant anyway.
+fn parse_job_state(state_str: &str) -> Option<crate::core::JobStateKind> {
+    use crate::core::JobStateKind;
     match state_str.to_lowercase().as_str() {
-        "enqueued" => Some(JobState::enqueued("default")),
-        "processing" => Some(JobState::processing("worker", "server")),
-        "succeeded" => Some(JobState::succeeded(0, None)),
-        "failed" => Some(JobState::failed("error", None)),
-        "scheduled" => Some(JobState::scheduled(chrono::Utc::now(), "reason")),
-        "awaiting_retry" | "awaitingretry" => {
-            Some(JobState::awaiting_retry(chrono::Utc::now(), "error"))
-        }
-        "deleted" => Some(JobState::deleted(None)),
+        "enqueued" => Some(JobStateKind::Enqueued),
+        "processing" => Some(JobStateKind::Processing),
+        "succeeded" => Some(JobStateKind::Succeeded),
+        "failed" => Some(JobStateKind::Failed),
+        "scheduled" => Some(JobStateKind::Scheduled),
+        "awaiting_retry" | "awaitingretry" => Some(JobStateKind::AwaitingRetry),
+        "deleted" => Some(JobStateKind::Deleted),
         _ => None,
     }
 }

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -132,7 +132,7 @@ impl DashboardServer {
         // Start periodic statistics updates with cancellation plumbed
         // through. The handle is awaited after the HTTP server exits so the
         // task can't outlive this call.
-        let periodic_handle = self
+        let mut periodic_handle = self
             .websocket_manager
             .start_periodic_updates(self.config.statistics_update_interval, cancel.clone())
             .await;
@@ -149,7 +149,24 @@ impl DashboardServer {
         // Ensure the periodic task observes shutdown even if axum::serve
         // exited because of an error rather than the token firing.
         cancel.cancel();
-        let _ = periodic_handle.await;
+
+        // Bound the wait. The periodic task should exit on the next
+        // `tokio::select!` poll once `cancel` fires, but
+        // `get_server_statistics()` can in principle stall indefinitely
+        // against an unhealthy backend. If it doesn't unwind in 5s,
+        // abort it and move on — better than blocking the caller's
+        // shutdown sequence.
+        match tokio::time::timeout(std::time::Duration::from_secs(5), &mut periodic_handle).await {
+            Ok(_) => {}
+            Err(_) => {
+                tracing::warn!(
+                    "Dashboard periodic-updates task did not exit within 5s of \
+                     cancellation; aborting"
+                );
+                periodic_handle.abort();
+                let _ = periodic_handle.await;
+            }
+        }
 
         serve_result?;
         Ok(())

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -2,6 +2,7 @@ use axum::{Router, http::StatusCode, middleware, response::Html, routing::get};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
 
@@ -63,6 +64,14 @@ pub struct DashboardServer {
     config: DashboardConfig,
     dashboard_service: Arc<DashboardService>,
     websocket_manager: Arc<WebSocketManager>,
+    /// Cancellation token wired into both `axum::serve(...).with_graceful_shutdown`
+    /// and the websocket periodic-updates task. [`shutdown`](Self::shutdown)
+    /// fires it; both the HTTP server and the periodic task observe it and
+    /// exit cleanly. Without this, the previous code's `tokio::spawn` for
+    /// periodic updates ran forever (no cancellation, no JoinHandle), and
+    /// `axum::serve` blocked indefinitely so embedding the dashboard in a
+    /// larger app's shutdown sequence wasn't possible.
+    shutdown: CancellationToken,
 }
 
 impl DashboardServer {
@@ -74,11 +83,38 @@ impl DashboardServer {
             config,
             dashboard_service,
             websocket_manager,
+            shutdown: CancellationToken::new(),
         }
     }
 
-    /// Start the dashboard server
+    /// Returns a clone of the internal shutdown token so callers can fire it
+    /// from their own runtime hooks (e.g. `tokio::signal::ctrl_c`) or wire
+    /// it into a parent `BackgroundJobServer`'s shutdown sequence.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// Trigger graceful shutdown of an active [`start`](Self::start) call.
+    /// The HTTP listener stops accepting new connections, in-flight requests
+    /// drain, and the periodic-updates task exits.
+    pub fn shutdown(&self) {
+        self.shutdown.cancel();
+    }
+
+    /// Start the dashboard server. Runs until [`shutdown`](Self::shutdown)
+    /// (or any clone of [`shutdown_token`](Self::shutdown_token)) fires, or
+    /// until the listener errors.
     pub async fn start(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.run_until_cancelled(self.shutdown.clone()).await
+    }
+
+    /// Like [`start`](Self::start) but exits cleanly when `cancel` fires.
+    /// Use this when embedding the dashboard alongside other services that
+    /// share a single cancellation source.
+    pub async fn run_until_cancelled(
+        &self,
+        cancel: CancellationToken,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.config.auth.is_none() && !auth::is_loopback_host(&self.config.host) {
             return Err(format!(
                 "refusing to start dashboard on non-loopback host '{}' without \
@@ -93,17 +129,29 @@ impl DashboardServer {
         // Create the main router
         let app = self.create_app().await;
 
-        // Start periodic statistics updates
-        self.websocket_manager
-            .start_periodic_updates(self.config.statistics_update_interval)
+        // Start periodic statistics updates with cancellation plumbed
+        // through. The handle is awaited after the HTTP server exits so the
+        // task can't outlive this call.
+        let periodic_handle = self
+            .websocket_manager
+            .start_periodic_updates(self.config.statistics_update_interval, cancel.clone())
             .await;
 
         tracing::info!("Starting QML Dashboard server on http://{}", addr);
         tracing::info!("Dashboard available at: http://{}", addr);
 
         let listener = TcpListener::bind(addr).await?;
-        axum::serve(listener, app).await?;
+        let serve_cancel = cancel.clone();
+        let serve_result = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { serve_cancel.cancelled().await })
+            .await;
 
+        // Ensure the periodic task observes shutdown even if axum::serve
+        // exited because of an error rather than the token firing.
+        cancel.cancel();
+        let _ = periodic_handle.await;
+
+        serve_result?;
         Ok(())
     }
 

--- a/src/dashboard/service.rs
+++ b/src/dashboard/service.rs
@@ -199,10 +199,13 @@ impl DashboardService {
     }
 
     /// Get jobs by state (limited sample)
-    pub async fn get_jobs_by_state(&self, state: JobState) -> Result<Vec<JobDetails>, QmlError> {
+    pub async fn get_jobs_by_state(
+        &self,
+        kind: crate::core::JobStateKind,
+    ) -> Result<Vec<JobDetails>, QmlError> {
         let jobs = self
             .storage
-            .list(Some(&state), Some(100), None)
+            .list(Some(kind), Some(100), None)
             .await
             .map_err(|e| QmlError::StorageError {
                 message: e.to_string(),

--- a/src/dashboard/service.rs
+++ b/src/dashboard/service.rs
@@ -262,7 +262,14 @@ impl DashboardService {
         }))
     }
 
-    /// Retry a failed job (simplified)
+    /// Retry a failed job.
+    ///
+    /// Uses [`Storage::update_if_state`] so concurrent dashboard
+    /// retries (or a retry racing with a worker that already picked
+    /// the job up after a peer's earlier retry) don't stomp on a
+    /// `Processing` state. Returns `Ok(false)` when the job has moved
+    /// out of `Failed` between read and write — the caller surfaces
+    /// this as "nothing to do" rather than a hard error.
     pub async fn retry_job(&self, job_id: &str) -> Result<bool, QmlError> {
         let mut job = match self
             .storage
@@ -275,21 +282,20 @@ impl DashboardService {
             None => return Ok(false),
         };
 
-        // Only retry failed jobs
+        // Only retry failed jobs.
         if !matches!(job.state, JobState::Failed { .. }) {
             return Ok(false);
         }
 
-        // Reset job state to enqueued for retry
+        // Reset job state to enqueued for retry.
         job.state = JobState::enqueued(&job.queue);
 
         self.storage
-            .update(&job)
+            .update_if_state(&job, crate::core::JobStateKind::Failed)
             .await
             .map_err(|e| QmlError::StorageError {
                 message: e.to_string(),
-            })?;
-        Ok(true)
+            })
     }
 
     /// Delete a job (simplified)

--- a/src/dashboard/service.rs
+++ b/src/dashboard/service.rs
@@ -186,7 +186,7 @@ impl DashboardService {
                     state: job.state,
                     created_at: job.created_at,
                     updated_at: job.created_at, // Use created_at as approximation
-                    attempts: 0,                // Not tracked in current Job struct
+                    attempts: job.attempt,
                     max_attempts: job.max_retries,
                     error_message,
                     scheduled_at,
@@ -221,7 +221,7 @@ impl DashboardService {
                     state: job.state,
                     created_at: job.created_at,
                     updated_at: job.created_at,
-                    attempts: 0,
+                    attempts: job.attempt,
                     max_attempts: job.max_retries,
                     error_message,
                     scheduled_at,
@@ -253,7 +253,7 @@ impl DashboardService {
                 state: job.state,
                 created_at: job.created_at,
                 updated_at: job.created_at,
-                attempts: 0,
+                attempts: job.attempt,
                 max_attempts: job.max_retries,
                 error_message,
                 scheduled_at,

--- a/src/dashboard/websocket.rs
+++ b/src/dashboard/websocket.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{RwLock, broadcast};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::dashboard::service::{DashboardService, ServerStatistics};
@@ -191,8 +193,19 @@ impl WebSocketManager {
         self.connections.read().await.len()
     }
 
-    /// Start periodic statistics broadcast
-    pub async fn start_periodic_updates(&self, interval_seconds: u64) {
+    /// Start periodic statistics broadcast.
+    ///
+    /// Returns a [`JoinHandle`] for the spawned task and exits cleanly when
+    /// `cancel` fires. The caller (typically [`crate::dashboard::DashboardServer`]) is expected
+    /// to await the handle on shutdown so the task doesn't outlive the
+    /// server's runtime — the previous version was a detached `tokio::spawn`
+    /// that ran forever and held an `Arc<DashboardService>` keeping storage
+    /// alive across drops.
+    pub async fn start_periodic_updates(
+        &self,
+        interval_seconds: u64,
+        cancel: CancellationToken,
+    ) -> JoinHandle<()> {
         let broadcast_sender = self.broadcast_sender.clone();
         let dashboard_service = Arc::clone(&self.dashboard_service);
 
@@ -201,16 +214,20 @@ impl WebSocketManager {
                 tokio::time::interval(tokio::time::Duration::from_secs(interval_seconds));
 
             loop {
-                interval.tick().await;
-
-                if let Ok(stats) = dashboard_service.get_server_statistics().await {
-                    let msg = DashboardMessage::StatisticsUpdate { data: stats };
-                    let _ = broadcast_sender.send(msg);
-                } else {
-                    tracing::error!("Failed to get statistics for periodic update");
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    _ = interval.tick() => {
+                        if let Ok(stats) = dashboard_service.get_server_statistics().await {
+                            let msg = DashboardMessage::StatisticsUpdate { data: stats };
+                            let _ = broadcast_sender.send(msg);
+                        } else {
+                            tracing::error!("Failed to get statistics for periodic update");
+                        }
+                    }
                 }
             }
-        });
+        })
     }
 }
 

--- a/src/processing/scheduler.rs
+++ b/src/processing/scheduler.rs
@@ -79,7 +79,7 @@ impl JobScheduler {
 
             if let Err(e) = self
                 .process_due_jobs("scheduled", |storage, now, limit| async move {
-                    storage.fetch_due_scheduled_jobs(now, limit).await
+                    storage.claim_due_scheduled_jobs(now, limit).await
                 })
                 .await
             {
@@ -88,7 +88,7 @@ impl JobScheduler {
 
             if let Err(e) = self
                 .process_due_jobs("retry", |storage, now, limit| async move {
-                    storage.fetch_due_retry_jobs(now, limit).await
+                    storage.claim_due_retry_jobs(now, limit).await
                 })
                 .await
             {
@@ -97,10 +97,14 @@ impl JobScheduler {
         }
     }
 
-    /// Drain a single category of due jobs into the `Enqueued` state. `fetch`
-    /// selects whether we pull from the scheduled or retry index; the rest of
-    /// the pipeline is identical.
-    async fn process_due_jobs<F, Fut>(&self, kind: &str, fetch: F) -> Result<()>
+    /// Drain a single category of due jobs into the `Enqueued` state.
+    ///
+    /// `claim` is a backend-specific atomic primitive — it both selects due
+    /// jobs and transitions them to `Enqueued` in one operation, so two
+    /// schedulers running against the same backend can't both promote the
+    /// same job. The scheduler used to do the transition itself with a
+    /// follow-up `update`; that pattern was racy under multi-server.
+    async fn process_due_jobs<F, Fut>(&self, kind: &str, claim: F) -> Result<()>
     where
         F: FnOnce(Arc<dyn Storage>, DateTime<Utc>, usize) -> Fut,
         Fut: Future<Output = std::result::Result<Vec<Job>, StorageError>>,
@@ -108,37 +112,20 @@ impl JobScheduler {
         debug!("Checking for {} jobs ready for execution", kind);
 
         let now = Utc::now();
-        let ready_jobs = fetch(self.storage.clone(), now, self.batch_size)
+        let claimed_jobs = claim(self.storage.clone(), now, self.batch_size)
             .await
             .map_err(|e| QmlError::StorageError {
-                message: format!("Failed to fetch due {} jobs: {}", kind, e),
+                message: format!("Failed to claim due {} jobs: {}", kind, e),
             })?;
 
-        debug!(
-            "Found {} {} jobs ready for execution",
-            ready_jobs.len(),
-            kind
-        );
-
-        self.enqueue_due_jobs(ready_jobs, kind).await;
-        Ok(())
-    }
-
-    /// Transition a batch of due jobs into the Enqueued state.
-    async fn enqueue_due_jobs(&self, jobs: Vec<Job>, kind: &str) {
-        for mut job in jobs {
-            info!("Enqueueing {} job: {}", kind, job.id);
-
-            let enqueued_state = JobState::enqueued(&job.queue);
-            if let Err(e) = job.set_state(enqueued_state) {
-                error!("Failed to set job state to Enqueued: {}", e);
-                continue;
-            }
-
-            if let Err(e) = self.storage.update(&job).await {
-                error!("Failed to update job in storage: {}", e);
-            }
+        if !claimed_jobs.is_empty() {
+            info!(
+                "Promoted {} {} job(s) to Enqueued",
+                claimed_jobs.len(),
+                kind
+            );
         }
+        Ok(())
     }
 
     /// Schedule a job for future execution
@@ -219,10 +206,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Process scheduled jobs
+        // Process scheduled jobs (claim_due_scheduled_jobs does the
+        // Scheduled → Enqueued transition atomically inside storage).
         scheduler
             .process_due_jobs("scheduled", |storage, now, limit| async move {
-                storage.fetch_due_scheduled_jobs(now, limit).await
+                storage.claim_due_scheduled_jobs(now, limit).await
             })
             .await
             .unwrap();
@@ -280,7 +268,7 @@ mod tests {
         let scheduler = JobScheduler::new(storage.clone());
         scheduler
             .process_due_jobs("scheduled", |storage, now, limit| async move {
-                storage.fetch_due_scheduled_jobs(now, limit).await
+                storage.claim_due_scheduled_jobs(now, limit).await
             })
             .await
             .unwrap();
@@ -314,6 +302,59 @@ mod tests {
         let due = storage.fetch_due_retry_jobs(Utc::now(), 100).await.unwrap();
         assert_eq!(due.len(), 1);
         assert_eq!(due[0].id, due_id);
+    }
+
+    #[tokio::test]
+    async fn claim_due_scheduled_jobs_returns_enqueued_state_atomically() {
+        // Regression for I9: claim_due_scheduled_jobs is the contract that
+        // multi-server schedulers rely on to avoid double-promotion. Verify
+        // it transitions Scheduled → Enqueued in a single call (no follow-up
+        // update needed) and that a second call observes none of the
+        // already-claimed jobs.
+        let storage = Arc::new(MemoryStorage::new());
+
+        let mut due_ids = Vec::new();
+        for _ in 0..5 {
+            let mut job = Job::new("noop", serde_json::Value::Null);
+            job.set_state(JobState::scheduled(
+                Utc::now() - Duration::seconds(5),
+                "past",
+            ))
+            .unwrap();
+            due_ids.push(job.id.clone());
+            storage.enqueue(&job).await.unwrap();
+        }
+
+        let claimed = storage
+            .claim_due_scheduled_jobs(Utc::now(), 100)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 5, "all 5 due jobs must be claimed");
+        for job in &claimed {
+            assert!(
+                matches!(job.state, JobState::Enqueued { .. }),
+                "claim returns jobs already in Enqueued state, got {:?}",
+                job.state
+            );
+        }
+
+        // Second call must return zero — the storage already transitioned
+        // those jobs out of Scheduled. This is what protects multi-server
+        // deployments from double-enqueue.
+        let again = storage
+            .claim_due_scheduled_jobs(Utc::now(), 100)
+            .await
+            .unwrap();
+        assert!(
+            again.is_empty(),
+            "second claim must not re-pick already-promoted jobs"
+        );
+
+        // And the underlying rows are observably Enqueued.
+        for id in &due_ids {
+            let job = storage.get(id).await.unwrap().unwrap();
+            assert!(matches!(job.state, JobState::Enqueued { .. }));
+        }
     }
 
     #[tokio::test]

--- a/src/processing/server.rs
+++ b/src/processing/server.rs
@@ -7,7 +7,7 @@ use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
-use tokio::time::{interval, sleep};
+use tokio::time::{MissedTickBehavior, interval, sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -651,6 +651,12 @@ impl BackgroundJobServer {
                 .to_std()
                 .unwrap_or(std::time::Duration::from_secs(1)),
         );
+        // Default `Burst` makes a slow worker (one whose process_job ran
+        // longer than `polling_interval`) try to "catch up" by firing
+        // every missed tick back-to-back. That just hammers storage with
+        // queries the worker can't keep up with anyway. `Skip` collapses
+        // backed-up ticks into one — the right shape for a poller.
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
@@ -686,9 +692,14 @@ impl BackgroundJobServer {
                 Err(e) => {
                     error!("Error fetching jobs: {}", e);
                     // Back off on error, but remain cancellable during the nap.
+                    // Add jitter so a fleet of workers all observing the same
+                    // transient backend failure doesn't resume in lock-step
+                    // and stampede the recovering backend on every tick.
+                    let jitter_ms = fastrand::u64(0..1500);
+                    let backoff = std::time::Duration::from_millis(5_000 + jitter_ms);
                     tokio::select! {
                         _ = cancel.cancelled() => break,
-                        _ = sleep(std::time::Duration::from_secs(5)) => {}
+                        _ = sleep(backoff) => {}
                     }
                 }
             }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -482,11 +482,16 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn test_postgres_config_default() {
+        // `PostgresConfig::default()` reads DATABASE_URL when present, falling
+        // back to the hardcoded dev string. Compute the expected value the
+        // same way so this test is stable whether or not the surrounding
+        // environment exports DATABASE_URL — earlier we asserted the
+        // fallback unconditionally and broke under `DATABASE_URL=...
+        // cargo test` setups.
+        let expected_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgresql://postgres:password@localhost:5432/qml".to_string());
         let config = PostgresConfig::default();
-        assert_eq!(
-            config.database_url,
-            "postgresql://postgres:password@localhost:5432/qml"
-        );
+        assert_eq!(config.database_url, expected_url);
         assert_eq!(config.max_connections, 20);
         assert_eq!(config.min_connections, 1);
         assert_eq!(config.table_name, "qml_jobs");

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -61,21 +61,40 @@ pub enum StorageError {
     #[error("Invalid job data: {message}")]
     InvalidJobData { message: String },
 
-    /// Connection-specific error (shorthand)
+    /// Connection-specific error (shorthand). Carries an optional source so
+    /// the underlying driver error can be inspected via `Error::source()` or
+    /// downcast — earlier versions stringified the cause into `message` and
+    /// dropped the chain.
     #[error("Connection error: {message}")]
-    ConnectionError { message: String },
+    ConnectionError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 
     /// Serialization-specific error (shorthand)
     #[error("Serialization error: {message}")]
-    SerializationError { message: String },
+    SerializationError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 
     /// Deserialization-specific error (shorthand)
     #[error("Deserialization error: {message}")]
-    DeserializationError { message: String },
+    DeserializationError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 
     /// Operation-specific error (shorthand)
     #[error("Operation error: {message}")]
-    OperationError { message: String },
+    OperationError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 }
 
 impl StorageError {
@@ -178,6 +197,56 @@ impl StorageError {
             job_id: job_id.into(),
         }
     }
+
+    /// Connection-error shorthand with a captured source. Prefer this over
+    /// `ConnectionError { message, source: None }` so the cause chain is
+    /// preserved for downstream `Error::source()` callers.
+    pub fn conn_err<M, E>(message: M, source: E) -> Self
+    where
+        M: Into<String>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::ConnectionError {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Serialization-error shorthand with a captured source.
+    pub fn ser_err<M, E>(message: M, source: E) -> Self
+    where
+        M: Into<String>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::SerializationError {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Deserialization-error shorthand with a captured source.
+    pub fn de_err<M, E>(message: M, source: E) -> Self
+    where
+        M: Into<String>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::DeserializationError {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Operation-error shorthand with a captured source.
+    pub fn op_err<M, E>(message: M, source: E) -> Self
+    where
+        M: Into<String>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::OperationError {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
 }
 
 // Convert StorageError to QmlError for unified error handling
@@ -185,7 +254,15 @@ impl From<StorageError> for QmlError {
     fn from(err: StorageError) -> Self {
         match err {
             StorageError::JobNotFound { job_id } => QmlError::JobNotFound { job_id },
-            StorageError::Serialization { message, .. } => QmlError::SerializationError { message },
+            // Both Serialization shapes map onto QmlError::SerializationError.
+            // The shorthand variants previously fell through to the generic
+            // StorageError arm, which dropped the typed signal callers were
+            // relying on.
+            StorageError::Serialization { message, .. }
+            | StorageError::SerializationError { message, .. }
+            | StorageError::DeserializationError { message, .. } => {
+                QmlError::SerializationError { message }
+            }
             _ => QmlError::StorageError {
                 message: err.to_string(),
             },

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -259,6 +259,82 @@ impl Storage for MemoryStorage {
         Ok(due)
     }
 
+    async fn claim_due_scheduled_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        // One critical section: select-and-transition under the same write
+        // lock. No `.await` between the read and the writes, so a parallel
+        // scheduler instance against the same MemoryStorage can never see
+        // a Scheduled job after it's been claimed here.
+        let mut jobs = self.jobs.write().unwrap();
+
+        let mut due_ids: Vec<String> = jobs
+            .values()
+            .filter(|job| match &job.state {
+                JobState::Scheduled { enqueue_at, .. } => *enqueue_at <= now,
+                _ => false,
+            })
+            .map(|job| job.id.clone())
+            .collect();
+
+        // Stable order matching the read-only fetch_due_scheduled_jobs:
+        // priority desc, then created_at asc.
+        due_ids.sort_by(|a, b| {
+            let ja = &jobs[a];
+            let jb = &jobs[b];
+            jb.priority
+                .cmp(&ja.priority)
+                .then_with(|| ja.created_at.cmp(&jb.created_at))
+        });
+        due_ids.truncate(limit);
+
+        let mut claimed = Vec::with_capacity(due_ids.len());
+        for id in due_ids {
+            if let Some(job) = jobs.get_mut(&id) {
+                job.state = JobState::enqueued(&job.queue);
+                claimed.push(job.clone());
+            }
+        }
+        Ok(claimed)
+    }
+
+    async fn claim_due_retry_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        let mut jobs = self.jobs.write().unwrap();
+
+        let mut due_ids: Vec<String> = jobs
+            .values()
+            .filter(|job| match &job.state {
+                JobState::AwaitingRetry { retry_at, .. } => *retry_at <= now,
+                _ => false,
+            })
+            .map(|job| job.id.clone())
+            .collect();
+
+        due_ids.sort_by(|a, b| {
+            let ja = &jobs[a];
+            let jb = &jobs[b];
+            jb.priority
+                .cmp(&ja.priority)
+                .then_with(|| ja.created_at.cmp(&jb.created_at))
+        });
+        due_ids.truncate(limit);
+
+        let mut claimed = Vec::with_capacity(due_ids.len());
+        for id in due_ids {
+            if let Some(job) = jobs.get_mut(&id) {
+                job.state = JobState::enqueued(&job.queue);
+                claimed.push(job.clone());
+            }
+        }
+        Ok(claimed)
+    }
+
     async fn requeue_stranded_jobs(
         &self,
         stale_before: DateTime<Utc>,

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -77,10 +77,10 @@ impl MemoryStorage {
         }
     }
 
-    /// Filter jobs by state
-    fn filter_jobs_by_state(jobs: &HashMap<String, Job>, state: &JobState) -> Vec<Job> {
+    /// Filter jobs by state discriminant.
+    fn filter_jobs_by_state(jobs: &HashMap<String, Job>, kind: JobStateKind) -> Vec<Job> {
         jobs.values()
-            .filter(|job| std::mem::discriminant(&job.state) == std::mem::discriminant(state))
+            .filter(|job| job.state.kind() == kind)
             .cloned()
             .collect()
     }
@@ -161,14 +161,14 @@ impl MonitoringApi for MemoryStorage {
 
     async fn list(
         &self,
-        state_filter: Option<&JobState>,
+        state_filter: Option<JobStateKind>,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Job>, StorageError> {
         let jobs = self.jobs.read().unwrap();
 
-        let mut filtered_jobs: Vec<Job> = if let Some(state) = state_filter {
-            Self::filter_jobs_by_state(&jobs, state)
+        let mut filtered_jobs: Vec<Job> = if let Some(kind) = state_filter {
+            Self::filter_jobs_by_state(&jobs, kind)
         } else {
             jobs.values().cloned().collect()
         };
@@ -728,9 +728,8 @@ mod tests {
         assert_eq!(all_jobs.len(), 3);
 
         // Test list by state
-        let enqueued_state = JobState::enqueued("default");
         let enqueued_jobs = storage
-            .list(Some(&enqueued_state), None, None)
+            .list(Some(JobStateKind::Enqueued), None, None)
             .await
             .unwrap();
         assert_eq!(enqueued_jobs.len(), 1);

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -138,6 +138,22 @@ impl MonitoringApi for MemoryStorage {
         }
     }
 
+    async fn update_if_state(
+        &self,
+        job: &Job,
+        expected: JobStateKind,
+    ) -> Result<bool, StorageError> {
+        let mut jobs = self.jobs.write().unwrap();
+        match jobs.get(&job.id) {
+            None => Err(StorageError::job_not_found(job.id.clone())),
+            Some(existing) if existing.state.kind() != expected => Ok(false),
+            Some(_) => {
+                jobs.insert(job.id.clone(), job.clone());
+                Ok(true)
+            }
+        }
+    }
+
     async fn delete(&self, job_id: &str) -> Result<bool, StorageError> {
         let mut jobs = self.jobs.write().unwrap();
         Ok(jobs.remove(job_id).is_some())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -279,6 +279,37 @@ pub trait Storage: MonitoringApi + Send + Sync {
         limit: usize,
     ) -> Result<Vec<Job>, StorageError>;
 
+    /// Atomically claim due scheduled jobs and transition them to
+    /// `Enqueued`.
+    ///
+    /// Unlike [`fetch_due_scheduled_jobs`], this method performs the
+    /// `Scheduled → Enqueued` transition inside the storage engine so two
+    /// schedulers running against the same backend cannot promote the same
+    /// job twice. Returns the claimed jobs already in their post-transition
+    /// (`Enqueued`) state.
+    ///
+    /// Backends implement this as:
+    /// - **Postgres**: `UPDATE ... WHERE state_name = 'scheduled' AND
+    ///   <due predicate> RETURNING *` with `FOR UPDATE SKIP LOCKED`.
+    /// - **Redis**: a Lua script that decodes each candidate, checks the
+    ///   time predicate, and performs the SET + index swaps in one
+    ///   invocation.
+    /// - **Memory**: a single critical section under the jobs write lock.
+    async fn claim_due_scheduled_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError>;
+
+    /// Atomically claim due retry jobs and transition them to `Enqueued`.
+    /// Same contract as [`claim_due_scheduled_jobs`] but for jobs in the
+    /// `AwaitingRetry` state.
+    async fn claim_due_retry_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError>;
+
     /// Recover jobs stranded in the `Processing` state by a previous server
     /// instance.
     ///
@@ -890,6 +921,36 @@ impl Storage for StorageInstance {
             StorageInstance::Redis(storage) => storage.fetch_due_retry_jobs(now, limit).await,
             #[cfg(feature = "postgres")]
             StorageInstance::Postgres(storage) => storage.fetch_due_retry_jobs(now, limit).await,
+        }
+    }
+
+    async fn claim_due_scheduled_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        match self {
+            StorageInstance::Memory(storage) => storage.claim_due_scheduled_jobs(now, limit).await,
+            #[cfg(feature = "redis")]
+            StorageInstance::Redis(storage) => storage.claim_due_scheduled_jobs(now, limit).await,
+            #[cfg(feature = "postgres")]
+            StorageInstance::Postgres(storage) => {
+                storage.claim_due_scheduled_jobs(now, limit).await
+            }
+        }
+    }
+
+    async fn claim_due_retry_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        match self {
+            StorageInstance::Memory(storage) => storage.claim_due_retry_jobs(now, limit).await,
+            #[cfg(feature = "redis")]
+            StorageInstance::Redis(storage) => storage.claim_due_retry_jobs(now, limit).await,
+            #[cfg(feature = "postgres")]
+            StorageInstance::Postgres(storage) => storage.claim_due_retry_jobs(now, limit).await,
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
-use crate::core::{Job, JobState, JobStateKind, RecurringJob, ServerInfo};
+use crate::core::{Job, JobStateKind, RecurringJob, ServerInfo};
 
 pub mod config;
 pub mod database_init;
@@ -823,9 +823,16 @@ pub trait MonitoringApi: Send + Sync {
     async fn delete(&self, job_id: &str) -> Result<bool, StorageError>;
 
     /// List jobs with optional filtering and pagination.
+    ///
+    /// `state_filter` is a [`JobStateKind`] discriminant — every backend
+    /// already filters by discriminant only. The earlier signature took
+    /// `Option<&JobState>` and required callers (notably the dashboard
+    /// router) to construct throwaway `JobState` values with bogus inner
+    /// fields just to pick a variant. The fields were silently ignored
+    /// but the type system couldn't say so.
     async fn list(
         &self,
-        state_filter: Option<&JobState>,
+        state_filter: Option<JobStateKind>,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Job>, StorageError>;
@@ -882,7 +889,7 @@ impl MonitoringApi for StorageInstance {
 
     async fn list(
         &self,
-        state_filter: Option<&JobState>,
+        state_filter: Option<JobStateKind>,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Job>, StorageError> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -288,6 +288,17 @@ pub trait Storage: MonitoringApi + Send + Sync {
     /// job twice. Returns the claimed jobs already in their post-transition
     /// (`Enqueued`) state.
     ///
+    /// **Caller contract — important:** the storage engine has already
+    /// persisted the `Enqueued` transition by the time this call returns.
+    /// Callers must NOT call [`MonitoringApi::update`] (or any other write
+    /// path) on the returned jobs to "save" the transition — the persisted
+    /// row already reflects it. The intended usage is to consume the
+    /// returned jobs as observations only (e.g. for logging/metrics) and
+    /// let the regular worker fetch path pick them up via
+    /// [`fetch_and_lock_job`]. Re-writing them is harmless on Postgres and
+    /// the in-memory backend (the state is the same), but on Redis it
+    /// re-runs index churn for no reason.
+    ///
     /// Backends implement this as:
     /// - **Postgres**: `UPDATE ... WHERE state_name = 'scheduled' AND
     ///   <due predicate> RETURNING *` with `FOR UPDATE SKIP LOCKED`.
@@ -302,8 +313,9 @@ pub trait Storage: MonitoringApi + Send + Sync {
     ) -> Result<Vec<Job>, StorageError>;
 
     /// Atomically claim due retry jobs and transition them to `Enqueued`.
-    /// Same contract as [`claim_due_scheduled_jobs`] but for jobs in the
-    /// `AwaitingRetry` state.
+    /// Same contract as [`claim_due_scheduled_jobs`] (including the
+    /// "do-not-`update()`-the-returned-jobs" caller contract) but for jobs
+    /// in the `AwaitingRetry` state.
     async fn claim_due_retry_jobs(
         &self,
         now: DateTime<Utc>,
@@ -348,6 +360,22 @@ pub trait Storage: MonitoringApi + Send + Sync {
     /// * `Ok(Some(job))` - Job was successfully fetched and locked
     /// * `Ok(None)` - No jobs are available for processing
     /// * `Err(StorageError)` - Storage operation failed
+    ///
+    /// ## Backend caveats
+    ///
+    /// **Redis**: when `queues` is `Some` and non-empty, the Lua script
+    /// scans up to **1024 candidates** ordered by score from the global
+    /// available ZSET, returning the first whose `queue` matches the
+    /// filter. If your deployment can have more than 1024 ineligible-
+    /// queue jobs queued ahead of an eligible one, queue-scoped workers
+    /// can transiently return `Ok(None)` even though work for them
+    /// exists. The cap is bounded for predictability under Redis's
+    /// `lua-time-limit`; per-queue ZSETs (a future change) will make the
+    /// scan exact.
+    ///
+    /// **Postgres** and **Memory**: no such cap — the queue filter is
+    /// pushed down to the engine (SQL `WHERE queue_name = ANY(...)` on
+    /// Postgres) and applied exactly.
     ///
     /// ## Examples
     /// ```rust

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -779,18 +779,20 @@ impl StorageInstance {
 
 /// Dashboard-facing subset of storage operations.
 ///
-/// [`MonitoringApi`] carves out the five methods the Axum dashboard and its
+/// [`MonitoringApi`] carves out the methods the Axum dashboard and its
 /// [`DashboardService`](crate::dashboard::DashboardService) actually touch
-/// (`get`, `update`, `delete`, `list`, `get_job_counts`) so that dashboard
-/// tests can be written against a ~100-line fake instead of a full
-/// [`Storage`] backend. Every real [`Storage`] implementation is also a
-/// [`MonitoringApi`], so callers holding an `Arc<dyn Storage>` can pass it
-/// anywhere an `Arc<dyn MonitoringApi>` is expected via trait upcasting.
+/// (`get`, `update`, `update_if_state`, `delete`, `list`, `get_job_counts`)
+/// so that dashboard tests can be written against a small fake instead of
+/// a full [`Storage`] backend. Every real [`Storage`] implementation is
+/// also a [`MonitoringApi`], so callers holding an `Arc<dyn Storage>` can
+/// pass it anywhere an `Arc<dyn MonitoringApi>` is expected via trait
+/// upcasting.
 ///
-/// The trait deliberately includes `update` and `delete` even though they
-/// mutate state — the dashboard needs them for its retry-job and delete-job
-/// actions, and pretending they're read-only would force callers back onto
-/// the full [`Storage`] trait and defeat the testing payoff.
+/// The trait deliberately includes mutating methods even though it's
+/// scoped at observation/operations — the dashboard needs them for its
+/// retry-job and delete-job actions, and pretending they're read-only
+/// would force callers back onto the full [`Storage`] trait and defeat
+/// the testing payoff.
 #[async_trait]
 pub trait MonitoringApi: Send + Sync {
     /// Retrieve a job by its unique identifier.
@@ -798,6 +800,24 @@ pub trait MonitoringApi: Send + Sync {
 
     /// Update an existing job's state and metadata.
     async fn update(&self, job: &Job) -> Result<(), StorageError>;
+
+    /// Compare-and-swap variant of [`update`].
+    ///
+    /// Writes `job` only if the persisted row's state currently matches
+    /// `expected`. Returns `Ok(true)` when the update was applied,
+    /// `Ok(false)` when the state had moved on (a stomp was avoided),
+    /// and `Err(JobNotFound)` when no row exists for the id.
+    ///
+    /// Use this when a caller has read the job, decided to transition it
+    /// based on what it observed, and might race with a worker or a peer
+    /// dashboard. The dashboard "retry" button is the canonical example —
+    /// without CAS, a slow second retry could overwrite a `Processing`
+    /// state that a worker had already taken on after the first retry.
+    async fn update_if_state(
+        &self,
+        job: &Job,
+        expected: JobStateKind,
+    ) -> Result<bool, StorageError>;
 
     /// Remove a job from storage (soft or hard delete).
     async fn delete(&self, job_id: &str) -> Result<bool, StorageError>;
@@ -833,6 +853,20 @@ impl MonitoringApi for StorageInstance {
             StorageInstance::Redis(storage) => storage.update(job).await,
             #[cfg(feature = "postgres")]
             StorageInstance::Postgres(storage) => storage.update(job).await,
+        }
+    }
+
+    async fn update_if_state(
+        &self,
+        job: &Job,
+        expected: JobStateKind,
+    ) -> Result<bool, StorageError> {
+        match self {
+            StorageInstance::Memory(storage) => storage.update_if_state(job, expected).await,
+            #[cfg(feature = "redis")]
+            StorageInstance::Redis(storage) => storage.update_if_state(job, expected).await,
+            #[cfg(feature = "postgres")]
+            StorageInstance::Postgres(storage) => storage.update_if_state(job, expected).await,
         }
     }
 

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -54,6 +54,7 @@ impl PostgresStorage {
             .await
             .map_err(|e| StorageError::ConnectionError {
                 message: format!("Failed to connect to PostgreSQL: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let storage = Self { pool, config };
@@ -343,71 +344,83 @@ impl PostgresStorage {
             .try_get("id")
             .map_err(|e| StorageError::DeserializationError {
                 message: format!("Failed to get job ID: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let method_name: String =
             row.try_get("method_name")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get method name: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let payload: serde_json::Value =
             row.try_get("arguments")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get payload: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let created_at: DateTime<Utc> =
             row.try_get("created_at")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get created_at: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let state_name: String =
             row.try_get("state_name")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get state name: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let state_data: serde_json::Value =
             row.try_get("state_data")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get state data: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let queue_name: String =
             row.try_get("queue_name")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get queue name: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let priority: i32 =
             row.try_get("priority")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get priority: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let max_retries: i32 =
             row.try_get("max_retries")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get max_retries: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let current_retries: i32 =
             row.try_get("current_retries")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get current_retries: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let metadata_json: Option<serde_json::Value> =
             row.try_get("metadata")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get metadata: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let metadata: HashMap<String, String> = if let Some(meta) = metadata_json {
             serde_json::from_value(meta).map_err(|e| StorageError::DeserializationError {
                 message: format!("Failed to deserialize metadata: {}", e),
+                source: Some(Box::new(e)),
             })?
         } else {
             HashMap::new()
@@ -417,18 +430,21 @@ impl PostgresStorage {
             row.try_get("job_type")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get job_type: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let timeout_seconds: Option<i32> =
             row.try_get("timeout_seconds")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get timeout_seconds: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let expires_at: Option<DateTime<Utc>> =
             row.try_get("expires_at")
                 .map_err(|e| StorageError::DeserializationError {
                     message: format!("Failed to get expires_at: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let state = Self::data_to_job_state(&state_name, &state_data)?;
@@ -467,6 +483,7 @@ impl PostgresStorage {
     fn job_state_to_data(state: &JobState) -> Result<serde_json::Value, StorageError> {
         serde_json::to_value(state).map_err(|e| StorageError::SerializationError {
             message: format!("Failed to serialize job state: {}", e),
+            source: Some(Box::new(e)),
         })
     }
 
@@ -477,6 +494,7 @@ impl PostgresStorage {
     ) -> Result<JobState, StorageError> {
         serde_json::from_value(state_data.clone()).map_err(|e| StorageError::DeserializationError {
             message: format!("Failed to deserialize job state {}: {}", state_name, e),
+            source: Some(Box::new(e)),
         })
     }
 
@@ -518,6 +536,7 @@ impl PostgresStorage {
     fn row_to_server_info(row: &sqlx::postgres::PgRow) -> Result<ServerInfo, StorageError> {
         let err = |field: &str, e: sqlx::Error| StorageError::DeserializationError {
             message: format!("Failed to get {}: {}", field, e),
+            source: Some(Box::new(e)),
         };
         let worker_count: i32 = row
             .try_get("worker_count")
@@ -542,6 +561,7 @@ impl PostgresStorage {
     fn row_to_recurring(row: &sqlx::postgres::PgRow) -> Result<RecurringJob, StorageError> {
         let err = |field: &str, e: sqlx::Error| StorageError::DeserializationError {
             message: format!("Failed to get {}: {}", field, e),
+            source: Some(Box::new(e)),
         };
         Ok(RecurringJob {
             id: row.try_get("id").map_err(|e| err("id", e))?,
@@ -610,6 +630,7 @@ impl MonitoringApi for PostgresStorage {
             Some(serde_json::to_value(&job.metadata).map_err(|e| {
                 StorageError::SerializationError {
                     message: format!("Failed to serialize metadata: {}", e),
+                    source: Some(Box::new(e)),
                 }
             })?)
         };
@@ -648,6 +669,7 @@ impl MonitoringApi for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to update job: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         if result.rows_affected() == 0 {
@@ -672,6 +694,7 @@ impl MonitoringApi for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to delete job: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         Ok(result.rows_affected() > 0)
@@ -731,6 +754,7 @@ impl MonitoringApi for PostgresStorage {
                 .await
                 .map_err(|e| StorageError::OperationError {
                     message: format!("Failed to list jobs: {}", e),
+                    source: Some(Box::new(e)),
                 })?;
 
         let mut jobs = Vec::new();
@@ -752,6 +776,7 @@ impl MonitoringApi for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to get job counts: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let mut counts = HashMap::new();
@@ -761,12 +786,14 @@ impl MonitoringApi for PostgresStorage {
                 row.try_get("state_name")
                     .map_err(|e| StorageError::DeserializationError {
                         message: format!("Failed to get state name from count query: {}", e),
+                        source: Some(Box::new(e)),
                     })?;
 
             let count: i64 =
                 row.try_get("count")
                     .map_err(|e| StorageError::DeserializationError {
                         message: format!("Failed to get count from count query: {}", e),
+                        source: Some(Box::new(e)),
                     })?;
 
             let kind = match state_name.as_str() {
@@ -797,6 +824,7 @@ impl Storage for PostgresStorage {
             Some(serde_json::to_value(&job.metadata).map_err(|e| {
                 StorageError::SerializationError {
                     message: format!("Failed to serialize metadata: {}", e),
+                    source: Some(Box::new(e)),
                 }
             })?)
         };
@@ -870,6 +898,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to get available jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let mut jobs = Vec::new();
@@ -908,6 +937,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to fetch due scheduled jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let mut jobs = Vec::with_capacity(rows.len());
@@ -942,6 +972,106 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to fetch due retry jobs: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        let mut jobs = Vec::with_capacity(rows.len());
+        for row in rows {
+            jobs.push(Self::row_to_job(&row)?);
+        }
+        Ok(jobs)
+    }
+
+    async fn claim_due_scheduled_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        // Atomic claim: select due-scheduled rows with FOR UPDATE SKIP
+        // LOCKED, transition them to Enqueued, and return the rows in
+        // their post-transition shape — all in one statement. Two
+        // schedulers running against the same database cannot both
+        // promote the same row.
+        let query = format!(
+            r#"
+            WITH due AS (
+                SELECT id FROM {table}
+                WHERE state_name = 'scheduled'
+                  AND (state_data->>'enqueue_at')::timestamptz <= $1
+                ORDER BY priority DESC, created_at ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT $2
+            )
+            UPDATE {table} AS j
+            SET state_name = 'enqueued',
+                state_data = jsonb_build_object(
+                    'enqueued_at', to_jsonb(NOW()),
+                    'queue', j.queue_name
+                )
+            WHERE j.id IN (SELECT id FROM due)
+            RETURNING j.id, j.method_name, j.arguments, j.created_at, j.state_name,
+                      j.state_data, j.queue_name, j.priority, j.max_retries,
+                      j.current_retries, j.metadata, j.job_type, j.timeout_seconds,
+                      j.expires_at
+            "#,
+            table = self.table_name()
+        );
+
+        let rows = sqlx::query(&query)
+            .bind(now)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to claim due scheduled jobs: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        let mut jobs = Vec::with_capacity(rows.len());
+        for row in rows {
+            jobs.push(Self::row_to_job(&row)?);
+        }
+        Ok(jobs)
+    }
+
+    async fn claim_due_retry_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        let query = format!(
+            r#"
+            WITH due AS (
+                SELECT id FROM {table}
+                WHERE state_name = 'awaiting_retry'
+                  AND (state_data->>'retry_at')::timestamptz <= $1
+                ORDER BY priority DESC, created_at ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT $2
+            )
+            UPDATE {table} AS j
+            SET state_name = 'enqueued',
+                state_data = jsonb_build_object(
+                    'enqueued_at', to_jsonb(NOW()),
+                    'queue', j.queue_name
+                )
+            WHERE j.id IN (SELECT id FROM due)
+            RETURNING j.id, j.method_name, j.arguments, j.created_at, j.state_name,
+                      j.state_data, j.queue_name, j.priority, j.max_retries,
+                      j.current_retries, j.metadata, j.job_type, j.timeout_seconds,
+                      j.expires_at
+            "#,
+            table = self.table_name()
+        );
+
+        let rows = sqlx::query(&query)
+            .bind(now)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to claim due retry jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         let mut jobs = Vec::with_capacity(rows.len());
@@ -983,6 +1113,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to requeue stranded jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         Ok(result.rows_affected() as usize)
@@ -1049,6 +1180,7 @@ impl Storage for PostgresStorage {
         let row = sqlx_query.fetch_optional(&self.pool).await.map_err(|e| {
             StorageError::OperationError {
                 message: format!("Failed to fetch and lock job: {}", e),
+                source: Some(Box::new(e)),
             }
         })?;
 
@@ -1079,6 +1211,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to acquire job lock: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         Ok(result)
@@ -1099,6 +1232,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to release job lock: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         Ok(result)
@@ -1158,6 +1292,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to upsert recurring job: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(())
     }
@@ -1170,6 +1305,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to delete recurring job: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() > 0)
     }
@@ -1189,6 +1325,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to list recurring jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
         rows.iter().map(Self::row_to_recurring).collect()
     }
@@ -1225,6 +1362,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to fetch due recurring jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         // The UPDATE parked the next_run_at to now + 3650d — restore the
@@ -1252,6 +1390,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to delete expired jobs: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() as usize)
     }
@@ -1282,6 +1421,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to register server: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(())
     }
@@ -1302,6 +1442,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to heartbeat server: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() > 0)
     }
@@ -1317,6 +1458,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to deregister server: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() > 0)
     }
@@ -1339,6 +1481,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to list dead servers: {}", e),
+                source: Some(Box::new(e)),
             })?;
         rows.iter().map(Self::row_to_server_info).collect()
     }
@@ -1372,6 +1515,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to reclaim jobs from server: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() as usize)
     }
@@ -1410,6 +1554,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to acquire lock: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(row.is_some())
     }
@@ -1427,6 +1572,7 @@ impl Storage for PostgresStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to release lock: {}", e),
+                source: Some(Box::new(e)),
             })?;
         Ok(result.rows_affected() > 0)
     }

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -739,6 +739,97 @@ impl MonitoringApi for PostgresStorage {
         Ok(())
     }
 
+    async fn update_if_state(
+        &self,
+        job: &Job,
+        expected: JobStateKind,
+    ) -> Result<bool, StorageError> {
+        let job_id = Uuid::from_str(&job.id).map_err(|e| StorageError::InvalidJobData {
+            message: format!("Invalid job ID format: {}", e),
+        })?;
+
+        let (new_state_name, new_state_data, arguments) = Self::job_to_row_values(job)?;
+        let metadata = if job.metadata.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_value(&job.metadata).map_err(|e| {
+                StorageError::SerializationError {
+                    message: format!("Failed to serialize metadata: {}", e),
+                    source: Some(Box::new(e)),
+                }
+            })?)
+        };
+
+        let expected_state_name = match expected {
+            JobStateKind::Enqueued => "enqueued",
+            JobStateKind::Processing => "processing",
+            JobStateKind::Succeeded => "succeeded",
+            JobStateKind::Failed => "failed",
+            JobStateKind::Deleted => "deleted",
+            JobStateKind::Scheduled => "scheduled",
+            JobStateKind::AwaitingRetry => "awaiting_retry",
+        };
+
+        // CAS in one round-trip: the predicate matches both the row id
+        // *and* the current state_name. If state has moved on,
+        // rows_affected = 0 and we follow up with a single SELECT to
+        // distinguish "stale state" (Ok(false)) from "row absent"
+        // (Err(JobNotFound)).
+        let query = format!(
+            r#"
+            UPDATE {}
+            SET method_name = $3, arguments = $4, state_name = $5, state_data = $6,
+                queue_name = $7, priority = $8, max_retries = $9, current_retries = $10,
+                metadata = $11, job_type = $12, timeout_seconds = $13, expires_at = $14,
+                updated_at = NOW()
+            WHERE id = $1 AND state_name = $2
+            "#,
+            self.table_name()
+        );
+
+        let result = sqlx::query(&query)
+            .bind(job_id)
+            .bind(expected_state_name)
+            .bind(&job.method)
+            .bind(arguments)
+            .bind(new_state_name)
+            .bind(new_state_data)
+            .bind(&job.queue)
+            .bind(job.priority)
+            .bind(job.max_retries as i32)
+            .bind(job.attempt as i32)
+            .bind(metadata)
+            .bind(&job.job_type)
+            .bind(job.timeout_seconds.map(|t| t as i32))
+            .bind(job.expires_at)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to update_if_state job: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        if result.rows_affected() > 0 {
+            return Ok(true);
+        }
+
+        // Distinguish missing from state-mismatch.
+        let exists_query = format!("SELECT 1 FROM {} WHERE id = $1", self.table_name());
+        let row_exists: Option<i32> = sqlx::query_scalar(&exists_query)
+            .bind(job_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to verify job existence: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        match row_exists {
+            Some(_) => Ok(false),
+            None => Err(StorageError::job_not_found(job.id.clone())),
+        }
+    }
+
     async fn delete(&self, job_id: &str) -> Result<bool, StorageError> {
         let job_uuid = Uuid::from_str(job_id).map_err(|e| StorageError::InvalidJobData {
             message: format!("Invalid job ID format: {}", e),

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -217,6 +217,64 @@ impl PostgresStorage {
         }
     }
 
+    /// Shared SQL for transitioning Processing rows back to Enqueued.
+    ///
+    /// Used by both `requeue_stranded_jobs` (filtered by staleness) and
+    /// `reclaim_jobs_from_server` (filtered by dead-peer server_name).
+    /// `where_filter` is appended after `WHERE state_name = 'processing'`
+    /// and may reference `$1` (the single bound parameter from `bind`).
+    ///
+    /// `to_jsonb(NOW())` is the canonical way to build a JSON timestamp
+    /// in Postgres — it produces an ISO-8601 string that round-trips
+    /// through chrono's serde format. The previous version of this code
+    /// used a hand-rolled `to_char(... 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`
+    /// mask which was sensitive to format-string drift between Postgres
+    /// versions and to chrono's deserialization expectations.
+    async fn update_processing_to_enqueued<F>(
+        &self,
+        where_filter: &str,
+        op_message: &str,
+        bind: F,
+    ) -> Result<usize, StorageError>
+    where
+        F: FnOnce(
+            sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,
+        ) -> sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    {
+        let query = format!(
+            r#"
+            UPDATE {table}
+            SET state_name = 'enqueued',
+                state_data = jsonb_build_object(
+                    'Enqueued',
+                    jsonb_build_object(
+                        'enqueued_at', to_jsonb(NOW()),
+                        'queue', queue_name
+                    )
+                ),
+                locked_by = NULL,
+                locked_at = NULL,
+                lock_expires_at = NULL,
+                updated_at = NOW()
+            WHERE state_name = 'processing'
+              {where_filter}
+            "#,
+            table = self.table_name(),
+            where_filter = where_filter,
+        );
+
+        let bound = bind(sqlx::query(&query));
+        let result = bound
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("{}: {}", op_message, e),
+                source: Some(Box::new(e)),
+            })?;
+
+        Ok(result.rows_affected() as usize)
+    }
+
     /// Run QML PostgreSQL schema installation
     ///
     /// This method installs the complete QML PostgreSQL schema using the embedded
@@ -881,8 +939,8 @@ impl Storage for PostgresStorage {
             WHERE state_name IN ('enqueued', 'scheduled', 'awaiting_retry')
             AND (
                 state_name = 'enqueued' OR
-                (state_name = 'scheduled' AND (state_data->>'enqueue_at')::timestamp <= NOW()) OR
-                (state_name = 'awaiting_retry' AND (state_data->>'retry_at')::timestamp <= NOW())
+                (state_name = 'scheduled' AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= NOW()) OR
+                (state_name = 'awaiting_retry' AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= NOW())
             )
             ORDER BY priority DESC, created_at ASC
             "#,
@@ -923,7 +981,7 @@ impl Storage for PostgresStorage {
                    queue_name, priority, max_retries, current_retries, metadata, job_type, timeout_seconds, expires_at
             FROM {}
             WHERE state_name = 'scheduled'
-              AND (state_data->>'enqueue_at')::timestamptz <= $1
+              AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= $1
             ORDER BY priority DESC, created_at ASC
             LIMIT $2
             "#,
@@ -958,7 +1016,7 @@ impl Storage for PostgresStorage {
                    queue_name, priority, max_retries, current_retries, metadata, job_type, timeout_seconds, expires_at
             FROM {}
             WHERE state_name = 'awaiting_retry'
-              AND (state_data->>'retry_at')::timestamptz <= $1
+              AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= $1
             ORDER BY priority DESC, created_at ASC
             LIMIT $2
             "#,
@@ -997,7 +1055,7 @@ impl Storage for PostgresStorage {
             WITH due AS (
                 SELECT id FROM {table}
                 WHERE state_name = 'scheduled'
-                  AND (state_data->>'enqueue_at')::timestamptz <= $1
+                  AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= $1
                 ORDER BY priority DESC, created_at ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2
@@ -1005,8 +1063,11 @@ impl Storage for PostgresStorage {
             UPDATE {table} AS j
             SET state_name = 'enqueued',
                 state_data = jsonb_build_object(
-                    'enqueued_at', to_jsonb(NOW()),
-                    'queue', j.queue_name
+                    'Enqueued',
+                    jsonb_build_object(
+                        'enqueued_at', to_jsonb(NOW()),
+                        'queue', j.queue_name
+                    )
                 )
             WHERE j.id IN (SELECT id FROM due)
             RETURNING j.id, j.method_name, j.arguments, j.created_at, j.state_name,
@@ -1044,7 +1105,7 @@ impl Storage for PostgresStorage {
             WITH due AS (
                 SELECT id FROM {table}
                 WHERE state_name = 'awaiting_retry'
-                  AND (state_data->>'retry_at')::timestamptz <= $1
+                  AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= $1
                 ORDER BY priority DESC, created_at ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2
@@ -1052,8 +1113,11 @@ impl Storage for PostgresStorage {
             UPDATE {table} AS j
             SET state_name = 'enqueued',
                 state_data = jsonb_build_object(
-                    'enqueued_at', to_jsonb(NOW()),
-                    'queue', j.queue_name
+                    'Enqueued',
+                    jsonb_build_object(
+                        'enqueued_at', to_jsonb(NOW()),
+                        'queue', j.queue_name
+                    )
                 )
             WHERE j.id IN (SELECT id FROM due)
             RETURNING j.id, j.method_name, j.arguments, j.created_at, j.state_name,
@@ -1085,38 +1149,17 @@ impl Storage for PostgresStorage {
         &self,
         stale_before: DateTime<Utc>,
     ) -> Result<usize, StorageError> {
-        // Single UPDATE: flips every stale Processing row back to Enqueued.
-        // `jsonb_build_object` synthesizes a fresh Enqueued state_data from
-        // the job's own `queue_name` column; `enqueued_at` is ISO-8601 so it
-        // round-trips through serde_json::from_value into chrono::DateTime.
-        let query = format!(
-            r#"
-            UPDATE {table}
-            SET state_name = 'enqueued',
-                state_data = jsonb_build_object(
-                    'enqueued_at', to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
-                    'queue', queue_name
-                ),
-                locked_by = NULL,
-                locked_at = NULL,
-                lock_expires_at = NULL,
-                updated_at = NOW()
-            WHERE state_name = 'processing'
-              AND (state_data->>'started_at')::timestamptz < $1
-            "#,
-            table = self.table_name()
-        );
-
-        let result = sqlx::query(&query)
-            .bind(stale_before)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StorageError::OperationError {
-                message: format!("Failed to requeue stranded jobs: {}", e),
-                source: Some(Box::new(e)),
-            })?;
-
-        Ok(result.rows_affected() as usize)
+        // Reused by `reclaim_jobs_from_server`; the only differences are
+        // the WHERE clause and the bound parameter. Keeping one source of
+        // truth for the Processing → Enqueued transition prevents the two
+        // call sites from drifting (an earlier version used a fragile
+        // hand-rolled to_char timestamp mask in only one of them).
+        self.update_processing_to_enqueued(
+            "AND (state_data->'Processing'->>'started_at')::timestamptz < $1",
+            "Failed to requeue stranded jobs",
+            |q| q.bind(stale_before),
+        )
+        .await
     }
 
     async fn fetch_and_lock_job(
@@ -1492,32 +1535,12 @@ impl Storage for PostgresStorage {
         // Matches every Processing job attributed to this dead peer and
         // flips it back to Enqueued so it can be re-picked by any live
         // worker.
-        let query = format!(
-            r#"
-            UPDATE {table}
-            SET state_name = 'enqueued',
-                state_data = jsonb_build_object(
-                    'enqueued_at', to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
-                    'queue', queue_name
-                ),
-                locked_by = NULL,
-                locked_at = NULL,
-                lock_expires_at = NULL,
-                updated_at = NOW()
-            WHERE state_name = 'processing'
-              AND state_data->>'server_name' = $1
-            "#,
-            table = self.table_name()
-        );
-        let result = sqlx::query(&query)
-            .bind(server_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StorageError::OperationError {
-                message: format!("Failed to reclaim jobs from server: {}", e),
-                source: Some(Box::new(e)),
-            })?;
-        Ok(result.rows_affected() as usize)
+        self.update_processing_to_enqueued(
+            "AND state_data->'Processing'->>'server_name' = $1",
+            "Failed to reclaim jobs from server",
+            |q| q.bind(server_id.to_string()),
+        )
+        .await
     }
 
     async fn try_acquire_lock(

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1628,10 +1628,11 @@ impl Storage for PostgresStorage {
 
     async fn reclaim_jobs_from_server(&self, server_id: &str) -> Result<usize, StorageError> {
         // Same shape as requeue_stranded_jobs but filtered on
-        // `state_data->>'server_name' = $1` instead of a staleness cutoff.
-        // Matches every Processing job attributed to this dead peer and
-        // flips it back to Enqueued so it can be re-picked by any live
-        // worker.
+        // `state_data->'Processing'->>'server_name' = $1` (note: the
+        // externally-tagged `Processing` wrapper) instead of a staleness
+        // cutoff. Matches every Processing job attributed to this dead
+        // peer and flips it back to Enqueued so it can be re-picked by
+        // any live worker.
         self.update_processing_to_enqueued(
             "AND state_data->'Processing'->>'server_name' = $1",
             "Failed to reclaim jobs from server",

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -526,14 +526,20 @@ impl PostgresStorage {
 
     /// Convert JobState to state name string
     fn job_state_to_name(state: &JobState) -> String {
-        match state {
-            JobState::Enqueued { .. } => "enqueued".to_string(),
-            JobState::Processing { .. } => "processing".to_string(),
-            JobState::Succeeded { .. } => "succeeded".to_string(),
-            JobState::Failed { .. } => "failed".to_string(),
-            JobState::Deleted { .. } => "deleted".to_string(),
-            JobState::Scheduled { .. } => "scheduled".to_string(),
-            JobState::AwaitingRetry { .. } => "awaiting_retry".to_string(),
+        Self::job_state_kind_to_name(state.kind()).to_string()
+    }
+
+    /// Convert a [`JobStateKind`] discriminant to the corresponding lowercase
+    /// `state_name` column value used in `qml_jobs`.
+    fn job_state_kind_to_name(kind: JobStateKind) -> &'static str {
+        match kind {
+            JobStateKind::Enqueued => "enqueued",
+            JobStateKind::Processing => "processing",
+            JobStateKind::Succeeded => "succeeded",
+            JobStateKind::Failed => "failed",
+            JobStateKind::Deleted => "deleted",
+            JobStateKind::Scheduled => "scheduled",
+            JobStateKind::AwaitingRetry => "awaiting_retry",
         }
     }
 
@@ -851,7 +857,7 @@ impl MonitoringApi for PostgresStorage {
 
     async fn list(
         &self,
-        state_filter: Option<&JobState>,
+        state_filter: Option<JobStateKind>,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Job>, StorageError> {
@@ -866,27 +872,27 @@ impl MonitoringApi for PostgresStorage {
 
         let mut param_count = 0;
 
-        if let Some(_state) = state_filter {
+        if state_filter.is_some() {
             param_count += 1;
             query.push_str(&format!(" WHERE state_name = ${}", param_count));
         }
 
         query.push_str(" ORDER BY created_at DESC");
 
-        if let Some(_limit) = limit {
+        if limit.is_some() {
             param_count += 1;
             query.push_str(&format!(" LIMIT ${}", param_count));
         }
 
-        if let Some(_offset) = offset {
+        if offset.is_some() {
             param_count += 1;
             query.push_str(&format!(" OFFSET ${}", param_count));
         }
 
         let mut sqlx_query = sqlx::query(&query);
 
-        if let Some(state) = state_filter {
-            sqlx_query = sqlx_query.bind(Self::job_state_to_name(state));
+        if let Some(kind) = state_filter {
+            sqlx_query = sqlx_query.bind(Self::job_state_kind_to_name(kind));
         }
 
         if let Some(limit_val) = limit {

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -383,30 +383,130 @@ impl MonitoringApi for RedisStorage {
     }
 
     async fn update(&self, job: &Job) -> Result<(), StorageError> {
-        let job_key = self.job_key(&job.id);
+        // Atomic update in a single Lua call: read the persisted blob to
+        // discover the *current* state (no TOCTOU), then write the new
+        // blob plus the index swap and counter math in one invocation.
+        //
+        // The earlier shape was a separate `get()` + `set()` pair in Rust
+        // with five non-transactional follow-up index commands, which:
+        //   1. Two concurrent updaters reading the same `old_state` would
+        //      both decrement the same old-state counter (drift).
+        //   2. A reader between the SET and the index commands could see a
+        //      job whose `state` field claimed e.g. `Processing` but whose
+        //      state-set membership and counts still said `Enqueued`.
+        //
+        // KEYS:
+        //   1. job key (full)
+        //   2. state index prefix
+        //   3. all_jobs key
+        //   4. available ZSET
+        //   5. counts hash
+        //
+        // ARGV:
+        //   1. new state name (lowercase, e.g. "enqueued")
+        //   2. new full job JSON to write
+        //   3. new score for the available ZSET, or "" if not available
+        //   4. new state availability flag ("1" if available, else "0")
+        //
+        // Returns "missing" if no job exists at the key, "ok" otherwise.
+        let lua_script = r#"
+            local job_key = KEYS[1]
+            local state_key_prefix = KEYS[2]
+            local all_jobs_key = KEYS[3]
+            local available_key = KEYS[4]
+            local counts_key = KEYS[5]
+            local new_state_name = ARGV[1]
+            local new_blob = ARGV[2]
+            local new_score = ARGV[3]
+            local new_available = ARGV[4]
 
-        // Get the current job to check if it exists and get old state
-        let current_job = self.get(&job.id).await?;
-        let old_state = current_job.as_ref().map(|j| &j.state);
+            local current = redis.call('GET', job_key)
+            if not current then
+                return 'missing'
+            end
 
-        if current_job.is_none() {
-            return Err(StorageError::job_not_found(job.id.clone()));
-        }
+            -- Determine old state from the persisted blob — atomically,
+            -- since this Lua run is the only thing touching the key while
+            -- it executes.
+            local old_job = cjson.decode(current)
+            local old_variant
+            for k, _ in pairs(old_job.state) do
+                old_variant = k
+                break
+            end
+            local old_state_name
+            if old_variant == 'AwaitingRetry' then
+                old_state_name = 'awaiting_retry'
+            else
+                old_state_name = string.lower(old_variant or '')
+            end
+
+            local job_id = old_job.id
+
+            redis.call('SET', job_key, new_blob)
+            redis.call('SADD', all_jobs_key, job_id)
+
+            if old_state_name ~= new_state_name then
+                redis.call('SREM', state_key_prefix .. old_state_name, job_id)
+                redis.call('SADD', state_key_prefix .. new_state_name, job_id)
+                redis.call('HINCRBY', counts_key, old_state_name, -1)
+                redis.call('HINCRBY', counts_key, new_state_name, 1)
+            end
+
+            if new_available == '1' then
+                redis.call('ZADD', available_key, tonumber(new_score), job_id)
+            else
+                redis.call('ZREM', available_key, job_id)
+            end
+
+            return 'ok'
+        "#;
 
         let mut conn = self.get_connection().await?;
-
-        // Serialize and store the updated job
-        let job_json = serde_json::to_string(job).map_err(|e| {
+        let new_blob = serde_json::to_string(job).map_err(|e| {
             StorageError::serialization_with_source("Failed to serialize job", Box::new(e))
         })?;
 
-        self.with_timeout::<_, ()>(conn.set(&job_key, job_json))
-            .await?;
+        let job_key = self.job_key(&job.id);
+        let state_key_prefix = format!("{}:state:", self.config.key_prefix);
+        let all_jobs_key = self.all_jobs_key();
+        let available_key = self.available_jobs_key();
+        let counts_key = self.job_counts_key();
 
-        // Update indices
-        self.update_job_indices(job, old_state).await?;
+        let new_state_name = Self::state_to_string(&job.state);
+        let (new_score, new_available) = if Self::is_job_available(job) {
+            let score =
+                job.priority as f64 + (job.created_at.timestamp_millis() as f64 / 1_000_000.0);
+            (score.to_string(), "1")
+        } else {
+            (String::new(), "0")
+        };
 
-        Ok(())
+        let result: String = redis::Script::new(lua_script)
+            .key(&job_key)
+            .key(&state_key_prefix)
+            .key(&all_jobs_key)
+            .key(&available_key)
+            .key(&counts_key)
+            .arg(&new_state_name)
+            .arg(&new_blob)
+            .arg(&new_score)
+            .arg(new_available)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to update job: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        match result.as_str() {
+            "ok" => Ok(()),
+            "missing" => Err(StorageError::job_not_found(job.id.clone())),
+            other => Err(StorageError::OperationError {
+                message: format!("Unexpected update response: {}", other),
+                source: None,
+            }),
+        }
     }
 
     async fn update_if_state(

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -417,6 +417,130 @@ impl MonitoringApi for RedisStorage {
         Ok(())
     }
 
+    async fn update_if_state(
+        &self,
+        job: &Job,
+        expected: JobStateKind,
+    ) -> Result<bool, StorageError> {
+        // Compare-and-swap in a single Lua call: GET the current job
+        // blob, decode, check the externally-tagged variant key against
+        // `expected`, and SET the new blob plus index updates only if
+        // it matches.
+        //
+        // KEYS[1] = job key (full)
+        // KEYS[2] = state index prefix
+        // KEYS[3] = available ZSET
+        // KEYS[4] = counts hash
+        // ARGV[1] = expected variant string ("Enqueued" / "Failed" / …)
+        // ARGV[2] = new variant string (for index swap)
+        // ARGV[3] = new full job JSON to write
+        // ARGV[4] = new score for the available ZSET (string), or "" if
+        //           the new state is not available
+        // ARGV[5] = new state availability flag ("1" if available, else "0")
+        //
+        // Returns:
+        //   "missing"   — no job at the key
+        //   "mismatch"  — job exists but state didn't match
+        //   "ok"        — applied
+        let lua_script = r#"
+            local job_key = KEYS[1]
+            local state_key_prefix = KEYS[2]
+            local available_key = KEYS[3]
+            local counts_key = KEYS[4]
+            local expected_variant = ARGV[1]
+            local new_variant = ARGV[2]
+            local new_blob = ARGV[3]
+            local new_score = ARGV[4]
+            local new_available = ARGV[5]
+
+            local current = redis.call('GET', job_key)
+            if not current then
+                return 'missing'
+            end
+            local job = cjson.decode(current)
+            if not job.state[expected_variant] then
+                return 'mismatch'
+            end
+
+            local old_variant = expected_variant
+
+            redis.call('SET', job_key, new_blob)
+            if old_variant ~= new_variant then
+                local lower_old = string.lower(old_variant)
+                local lower_new = string.lower(new_variant)
+                -- AwaitingRetry is stored as 'awaiting_retry' in the state
+                -- index key. The other variants are simple snake_case of the
+                -- camel-case variant name; for AwaitingRetry the lowercase
+                -- alone gives us 'awaitingretry' which is wrong.
+                if old_variant == 'AwaitingRetry' then lower_old = 'awaiting_retry' end
+                if new_variant == 'AwaitingRetry' then lower_new = 'awaiting_retry' end
+                redis.call('SREM', state_key_prefix .. lower_old, job.id)
+                redis.call('SADD', state_key_prefix .. lower_new, job.id)
+                redis.call('HINCRBY', counts_key, lower_old, -1)
+                redis.call('HINCRBY', counts_key, lower_new, 1)
+            end
+
+            if new_available == '1' then
+                redis.call('ZADD', available_key, tonumber(new_score), job.id)
+            else
+                redis.call('ZREM', available_key, job.id)
+            end
+
+            return 'ok'
+        "#;
+
+        let mut conn = self.get_connection().await?;
+        let new_blob = serde_json::to_string(job).map_err(|e| {
+            StorageError::serialization_with_source("Failed to serialize job", Box::new(e))
+        })?;
+
+        let job_key = self.job_key(&job.id);
+        let state_key_prefix = format!("{}:state:", self.config.key_prefix);
+        let available_key = self.available_jobs_key();
+        let counts_key = self.job_counts_key();
+
+        let new_kind = job.state.kind();
+        let new_variant = new_kind.name();
+        let expected_variant = expected.name();
+
+        // Match update_job_indices' score formula so the available ZSET
+        // remains consistent with the rest of the codebase.
+        let (new_score, new_available) = if Self::is_job_available(job) {
+            let score =
+                job.priority as f64 + (job.created_at.timestamp_millis() as f64 / 1_000_000.0);
+            (score.to_string(), "1")
+        } else {
+            (String::new(), "0")
+        };
+
+        let result: String = redis::Script::new(lua_script)
+            .key(&job_key)
+            .key(&state_key_prefix)
+            .key(&available_key)
+            .key(&counts_key)
+            .arg(expected_variant)
+            .arg(new_variant)
+            .arg(&new_blob)
+            .arg(&new_score)
+            .arg(new_available)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to update_if_state job: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+
+        match result.as_str() {
+            "ok" => Ok(true),
+            "mismatch" => Ok(false),
+            "missing" => Err(StorageError::job_not_found(job.id.clone())),
+            other => Err(StorageError::OperationError {
+                message: format!("Unexpected update_if_state response: {}", other),
+                source: None,
+            }),
+        }
+    }
+
     async fn delete(&self, job_id: &str) -> Result<bool, StorageError> {
         // Get the job first to update indices
         let job = match self.get(job_id).await? {

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -122,14 +122,20 @@ impl RedisStorage {
 
     /// Convert job state to a string for indexing
     fn state_to_string(state: &JobState) -> String {
-        match state {
-            JobState::Enqueued { .. } => "enqueued".to_string(),
-            JobState::Processing { .. } => "processing".to_string(),
-            JobState::Succeeded { .. } => "succeeded".to_string(),
-            JobState::Failed { .. } => "failed".to_string(),
-            JobState::Deleted { .. } => "deleted".to_string(),
-            JobState::Scheduled { .. } => "scheduled".to_string(),
-            JobState::AwaitingRetry { .. } => "awaiting_retry".to_string(),
+        Self::kind_to_state_name(state.kind()).to_string()
+    }
+
+    /// Convert a [`JobStateKind`] discriminant to the lowercase string
+    /// used in the `qml:state:<name>` index keys and the counts hash.
+    fn kind_to_state_name(kind: JobStateKind) -> &'static str {
+        match kind {
+            JobStateKind::Enqueued => "enqueued",
+            JobStateKind::Processing => "processing",
+            JobStateKind::Succeeded => "succeeded",
+            JobStateKind::Failed => "failed",
+            JobStateKind::Deleted => "deleted",
+            JobStateKind::Scheduled => "scheduled",
+            JobStateKind::AwaitingRetry => "awaiting_retry",
         }
     }
 
@@ -657,15 +663,14 @@ impl MonitoringApi for RedisStorage {
 
     async fn list(
         &self,
-        state_filter: Option<&JobState>,
+        state_filter: Option<JobStateKind>,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Job>, StorageError> {
         let mut conn = self.get_connection().await?;
 
-        let job_ids: Vec<String> = if let Some(state) = state_filter {
-            let state_str = Self::state_to_string(state);
-            let state_key = self.state_index_key(&state_str);
+        let job_ids: Vec<String> = if let Some(kind) = state_filter {
+            let state_key = self.state_index_key(Self::kind_to_state_name(kind));
             self.with_timeout(conn.smembers(&state_key)).await?
         } else {
             let all_jobs_key = self.all_jobs_key();
@@ -1566,9 +1571,8 @@ mod tests {
         assert_eq!(all_jobs.len(), 3);
 
         // Test list by state
-        let enqueued_state = JobState::enqueued("test");
         let enqueued_jobs = storage
-            .list(Some(&enqueued_state), None, None)
+            .list(Some(JobStateKind::Enqueued), None, None)
             .await
             .unwrap();
         assert_eq!(enqueued_jobs.len(), 1);

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -658,10 +658,18 @@ impl Storage for RedisStorage {
         let mut conn = self.get_connection().await?;
         let available_key = self.available_jobs_key();
 
-        // Get job IDs ordered by score (priority and creation time)
-        let count = limit.unwrap_or(-1_isize as usize) as isize;
+        // Get job IDs ordered by score (priority and creation time).
+        // ZREVRANGE uses inclusive indices: -1 means "the last element",
+        // i.e. "to the end". The earlier formulation
+        // `(-1_isize as usize) as isize` round-tripped to -1 then
+        // subtracted 1, giving -2 — which excludes the *last* element of
+        // the set, so a limit-less call lost one entry off the end.
+        let end_index: isize = match limit {
+            Some(n) => (n as isize) - 1,
+            None => -1,
+        };
         let job_ids: Vec<String> = self
-            .with_timeout(conn.zrevrange(&available_key, 0, count - 1))
+            .with_timeout(conn.zrevrange(&available_key, 0, end_index))
             .await?;
 
         let mut jobs = Vec::new();

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -245,6 +245,14 @@ impl RedisStorage {
     /// a non-trivial parse. Same-priority FIFO ordering is therefore
     /// approximate for newly-promoted jobs; it's accurate as long as the
     /// claim batch is small.
+    ///
+    /// Timestamp format: `now` is rendered as RFC3339 with microsecond
+    /// precision (`SecondsFormat::Micros`) and the `Z` suffix — the same
+    /// shape chrono's serde adapter produces for `DateTime<Utc>` and the
+    /// shape Postgres's `to_jsonb(NOW())` produces (modulo `Z` vs
+    /// `+00:00`, which both parse). All three sources share microsecond
+    /// precision so lexicographic comparison of the time field stays
+    /// chronological across backends.
     async fn claim_due_jobs_lua(
         &self,
         from_state_str: &str,
@@ -253,6 +261,14 @@ impl RedisStorage {
         now: DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<Job>, StorageError> {
+        // Defensive: bail on a zero limit without round-tripping to Redis.
+        // The trait permits `limit: usize`; callers (currently the
+        // scheduler) pass a positive batch size, but a future caller
+        // mistakenly passing 0 would otherwise issue an SMEMBERS for
+        // nothing.
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let mut conn = self.get_connection().await?;
 
         let lua_script = r#"

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -188,25 +188,17 @@ impl RedisStorage {
                 .await?;
         }
 
-        // Set TTL for completed/failed jobs if configured
-        match job.state {
-            JobState::Succeeded { .. } => {
-                if let Some(ttl) = self.config.completed_job_ttl {
-                    let job_key = self.job_key(&job.id);
-                    self.with_timeout::<_, ()>(conn.expire(&job_key, ttl.as_secs() as i64))
-                        .await?;
-                }
-            }
-            JobState::Failed { .. } => {
-                if let Some(ttl) = self.config.failed_job_ttl {
-                    let job_key = self.job_key(&job.id);
-                    self.with_timeout::<_, ()>(conn.expire(&job_key, ttl.as_secs() as i64))
-                        .await?;
-                }
-            }
-            _ => {}
-        }
-
+        // Expiration of final-state jobs is owned by `CleanupWorker` via
+        // `Storage::delete_expired_jobs`, which sweeps `expires_at` set by
+        // `JobProcessor` on transition. Native Redis EXPIRE used to also
+        // be set here, which raced the sweep: when the native TTL fired
+        // first, the job key disappeared but its index entries
+        // (qml:state:succeeded, qml:all, qml:counts) lived on forever
+        // because nothing observed the expiration. Stick with the
+        // out-of-band sweep — one expiration source, one consistent index.
+        // (`RedisConfig::completed_job_ttl` / `failed_job_ttl` remain on the
+        // public config for backward compatibility but no longer affect
+        // index lifecycle.)
         Ok(())
     }
 

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -231,6 +231,141 @@ impl RedisStorage {
 
         Ok(())
     }
+
+    /// Atomically claim due jobs out of a time-gated state (`scheduled` or
+    /// `awaiting_retry`) and transition them to `Enqueued`.
+    ///
+    /// `from_state_str` / `from_state_variant` / `time_field` parameterize
+    /// over Scheduled vs AwaitingRetry — the variant key in the externally-
+    /// tagged JSON layout, the index key, and the time field name on the
+    /// state. The whole select-decode-transition-update happens inside one
+    /// Lua invocation so a peer scheduler can't see a job after it's been
+    /// claimed here.
+    ///
+    /// Note: the available-set score uses `priority` only — chrono ISO
+    /// timestamps don't lex-sort correctly to a Redis float in Lua without
+    /// a non-trivial parse. Same-priority FIFO ordering is therefore
+    /// approximate for newly-promoted jobs; it's accurate as long as the
+    /// claim batch is small.
+    async fn claim_due_jobs_lua(
+        &self,
+        from_state_str: &str,
+        from_state_variant: &str,
+        time_field: &str,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        let mut conn = self.get_connection().await?;
+
+        let lua_script = r#"
+            local from_state_key = KEYS[1]
+            local to_state_key = KEYS[2]
+            local available_key = KEYS[3]
+            local job_key_prefix = KEYS[4]
+            local counts_key = KEYS[5]
+            local from_state_name = ARGV[1]
+            local from_state_variant = ARGV[2]
+            local time_field = ARGV[3]
+            local now_iso = ARGV[4]
+            local limit = tonumber(ARGV[5])
+
+            local candidate_ids = redis.call('SMEMBERS', from_state_key)
+
+            -- Collect due candidates with their priority and creation time.
+            local due = {}
+            for _, job_id in ipairs(candidate_ids) do
+                local job_key = job_key_prefix .. job_id
+                local job_data = redis.call('GET', job_key)
+                if not job_data then
+                    -- Index drift: id in state set but no job blob. Clean up.
+                    redis.call('SREM', from_state_key, job_id)
+                else
+                    local job = cjson.decode(job_data)
+                    local outer = job.state[from_state_variant]
+                    if outer and outer[time_field] and outer[time_field] <= now_iso then
+                        table.insert(due, {
+                            id = job_id,
+                            priority = job.priority or 0,
+                            created_at = job.created_at or '',
+                            parsed = job
+                        })
+                    end
+                end
+            end
+
+            -- Order by priority desc, then created_at asc — matches the SQL
+            -- backend's ORDER BY clause. ISO timestamps with consistent
+            -- format sort lexicographically the same as chronologically.
+            table.sort(due, function(a, b)
+                if a.priority ~= b.priority then return a.priority > b.priority end
+                return a.created_at < b.created_at
+            end)
+
+            local claimed = {}
+            local n = math.min(limit, #due)
+            for i = 1, n do
+                local entry = due[i]
+                local job = entry.parsed
+
+                job.state = {
+                    Enqueued = {
+                        enqueued_at = now_iso,
+                        queue = job.queue
+                    }
+                }
+                job.updated_at = now_iso
+
+                local new_data = cjson.encode(job)
+                local job_key = job_key_prefix .. entry.id
+                redis.call('SET', job_key, new_data)
+                redis.call('SREM', from_state_key, entry.id)
+                redis.call('SADD', to_state_key, entry.id)
+                redis.call('ZADD', available_key, tostring(entry.priority), entry.id)
+                redis.call('HINCRBY', counts_key, from_state_name, -1)
+                redis.call('HINCRBY', counts_key, 'enqueued', 1)
+                table.insert(claimed, new_data)
+            end
+
+            return claimed
+        "#;
+
+        let from_state_key = self.state_index_key(from_state_str);
+        let to_state_key = self.state_index_key("enqueued");
+        let available_key = self.available_jobs_key();
+        let job_key_prefix = format!("{}:jobs:", self.config.key_prefix);
+        let counts_key = self.job_counts_key();
+        let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+        let result: Vec<String> = redis::Script::new(lua_script)
+            .key(&from_state_key)
+            .key(&to_state_key)
+            .key(&available_key)
+            .key(&job_key_prefix)
+            .key(&counts_key)
+            .arg(from_state_str)
+            .arg(from_state_variant)
+            .arg(time_field)
+            .arg(&now_iso)
+            .arg(limit as i64)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to claim due {} jobs: {}", from_state_str, e),
+                source: Some(Box::new(e)),
+            })?;
+
+        let mut jobs = Vec::with_capacity(result.len());
+        for json in result {
+            let job: Job = serde_json::from_str(&json).map_err(|e| {
+                StorageError::serialization_with_source(
+                    format!("Failed to parse claimed {} job", from_state_str),
+                    Box::new(e),
+                )
+            })?;
+            jobs.push(job);
+        }
+        Ok(jobs)
+    }
 }
 
 #[async_trait]
@@ -483,6 +618,24 @@ impl Storage for RedisStorage {
         Ok(due)
     }
 
+    async fn claim_due_scheduled_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        self.claim_due_jobs_lua("scheduled", "Scheduled", "enqueue_at", now, limit)
+            .await
+    }
+
+    async fn claim_due_retry_jobs(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Job>, StorageError> {
+        self.claim_due_jobs_lua("awaiting_retry", "AwaitingRetry", "retry_at", now, limit)
+            .await
+    }
+
     async fn requeue_stranded_jobs(
         &self,
         stale_before: DateTime<Utc>,
@@ -523,83 +676,158 @@ impl Storage for RedisStorage {
     async fn fetch_and_lock_job(
         &self,
         worker_id: &str,
-        _queues: Option<&[String]>,
+        queues: Option<&[String]>,
     ) -> Result<Option<Job>, StorageError> {
         let mut conn = self.get_connection().await?;
 
-        // Lua script for atomic job fetching and locking
+        // Lua script for atomic job fetching and locking.
+        //
+        // KEYS:
+        //   1. available jobs ZSET key (full)
+        //   2. job key prefix (e.g. "qml:jobs:") — concatenated with the
+        //      job id to form the full job key
+        //   3. state index key prefix (e.g. "qml:state:") — concatenated
+        //      with the state name (e.g. "enqueued") to form the full key
+        //   4. counts hash key (full)
+        //
+        // ARGV:
+        //   1. worker_id
+        //   2. now_iso — RFC3339 timestamp string for both
+        //      JobState::Processing.started_at and Job.updated_at. Passed
+        //      from Rust so the JSON timestamps round-trip through
+        //      `chrono::DateTime<Utc>` cleanly (cjson can't format dates).
+        //   3. queue filter as a JSON array, or "" for no filter
+        //   4. candidate cap — upper bound on entries scanned from the
+        //      available ZSET. Without a queue filter we only need 1.
+        //      With a filter we may need to scan past ineligible jobs.
         let lua_script = r#"
             local available_key = KEYS[1]
+            local job_key_prefix = KEYS[2]
+            local state_key_prefix = KEYS[3]
+            local counts_key = KEYS[4]
             local worker_id = ARGV[1]
-            local current_time = tonumber(ARGV[2])
-            
-            -- Get the job with highest priority (lowest score)
-            local job_ids = redis.call('ZRANGEBYSCORE', available_key, '-inf', '+inf', 'LIMIT', 0, 1)
-            
-            if #job_ids == 0 then
-                return nil  -- No jobs available
-            end
-            
-            local job_id = job_ids[1]
-            local job_key = 'qml:job:' .. job_id
-            
-            -- Get the job data
-            local job_data = redis.call('GET', job_key)
-            if not job_data then
-                -- Job was deleted, remove from available set
-                redis.call('ZREM', available_key, job_id)
-                return nil
-            end
-            
-            -- Parse job to check if it's still available. JobState is
-            -- externally tagged by serde, so the variant surfaces as a single
-            -- key on job.state (e.g. Enqueued, AwaitingRetry). Any job whose
-            -- variant is not Enqueued or AwaitingRetry is not eligible.
-            local job = cjson.decode(job_data)
-            if not (job.state.Enqueued or job.state.AwaitingRetry) then
-                redis.call('ZREM', available_key, job_id)
-                return nil
+            local now_iso = ARGV[2]
+            local queue_filter_json = ARGV[3]
+            local cap = tonumber(ARGV[4])
+
+            local filter_set = nil
+            if queue_filter_json ~= '' then
+                local arr = cjson.decode(queue_filter_json)
+                if #arr > 0 then
+                    filter_set = {}
+                    for _, q in ipairs(arr) do
+                        filter_set[q] = true
+                    end
+                end
             end
 
-            -- Mark job as processing, matching the externally-tagged layout
-            -- so Rust can deserialize it back into JobState::Processing.
-            job.state = {
-                Processing = {
-                    worker_id = worker_id,
-                    started_at = current_time,
-                    server_name = 'redis-storage'
-                }
-            }
-            job.updated_at = current_time
+            -- Pull a candidate batch ordered by score DESC (highest priority
+            -- first). Score is built in update_job_indices as
+            -- `priority + created_at_ms / 1e6` so higher score = higher
+            -- priority, with creation time breaking priority ties.
+            local candidates = redis.call(
+                'ZREVRANGEBYSCORE', available_key, '+inf', '-inf',
+                'LIMIT', 0, cap
+            )
 
-            -- Update job in Redis
-            redis.call('SET', job_key, cjson.encode(job))
+            for _, job_id in ipairs(candidates) do
+                local job_key = job_key_prefix .. job_id
+                local job_data = redis.call('GET', job_key)
+                if not job_data then
+                    -- Job was deleted; clean up the available set.
+                    redis.call('ZREM', available_key, job_id)
+                else
+                    -- JobState is externally tagged by serde, so the variant
+                    -- surfaces as a single key on job.state.
+                    local job = cjson.decode(job_data)
+                    local from_enqueued = job.state.Enqueued ~= nil
+                    local from_retry = job.state.AwaitingRetry ~= nil
+                    if not (from_enqueued or from_retry) then
+                        -- Stale entry in the available set; remove and move on.
+                        redis.call('ZREM', available_key, job_id)
+                    else
+                        local matches = (filter_set == nil) or filter_set[job.queue]
+                        if matches then
+                            local old_state_name
+                            if from_enqueued then
+                                old_state_name = 'enqueued'
+                            else
+                                old_state_name = 'awaiting_retry'
+                            end
 
-            -- Remove from available jobs and update indices
-            redis.call('ZREM', available_key, job_id)
-            redis.call('SREM', 'qml:state:enqueued', job_id)
-            redis.call('SREM', 'qml:state:awaiting_retry', job_id)
-            redis.call('SADD', 'qml:state:processing', job_id)
+                            -- Mark job as processing, matching the
+                            -- externally-tagged layout so Rust can
+                            -- deserialize it back into JobState::Processing.
+                            -- Timestamps are passed as ISO strings because
+                            -- chrono's serde format is RFC3339 — feeding raw
+                            -- millis here would break deserialization.
+                            job.state = {
+                                Processing = {
+                                    worker_id = worker_id,
+                                    started_at = now_iso,
+                                    server_name = 'redis-storage'
+                                }
+                            }
+                            job.updated_at = now_iso
 
-            -- Update counters
-            redis.call('HINCRBY', 'qml:counts', 'enqueued', -1)
-            redis.call('HINCRBY', 'qml:counts', 'awaiting_retry', -1)
-            redis.call('HINCRBY', 'qml:counts', 'processing', 1)
-            
-            return job_data
+                            local new_job_data = cjson.encode(job)
+                            redis.call('SET', job_key, new_job_data)
+                            redis.call('ZREM', available_key, job_id)
+                            redis.call('SREM', state_key_prefix .. old_state_name, job_id)
+                            redis.call('SADD', state_key_prefix .. 'processing', job_id)
+                            redis.call('HINCRBY', counts_key, old_state_name, -1)
+                            redis.call('HINCRBY', counts_key, 'processing', 1)
+
+                            return new_job_data
+                        end
+                    end
+                end
+            end
+
+            return nil
         "#;
 
         let available_key = self.available_jobs_key();
-        let current_time = chrono::Utc::now().timestamp_millis();
+        let job_key_prefix = format!("{}:jobs:", self.config.key_prefix);
+        let state_key_prefix = format!("{}:state:", self.config.key_prefix);
+        let counts_key = self.job_counts_key();
+        let now_iso = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+
+        // Bound how far the script will scan when filtering by queue. Without
+        // a filter we only need 1. With a filter, we may have to skip over
+        // ineligible-queue jobs to find one that matches; cap the scan to
+        // keep the script bounded. 1024 is well within Redis's default
+        // lua-time-limit and large enough to be effectively "all" for most
+        // realistic backlogs.
+        let cap = match queues {
+            Some(qs) if !qs.is_empty() => 1024,
+            _ => 1,
+        };
+
+        let queue_filter = match queues {
+            Some(qs) if !qs.is_empty() => serde_json::to_string(qs).map_err(|e| {
+                StorageError::serialization_with_source(
+                    "Failed to serialize queue filter",
+                    Box::new(e),
+                )
+            })?,
+            _ => String::new(),
+        };
 
         let result: Option<String> = redis::Script::new(lua_script)
             .key(&available_key)
+            .key(&job_key_prefix)
+            .key(&state_key_prefix)
+            .key(&counts_key)
             .arg(worker_id)
-            .arg(current_time)
+            .arg(&now_iso)
+            .arg(&queue_filter)
+            .arg(cap)
             .invoke_async(&mut conn)
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to fetch and lock job: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         if let Some(job_json) = result {
@@ -664,6 +892,7 @@ impl Storage for RedisStorage {
             .await
             .map_err(|e| StorageError::OperationError {
                 message: format!("Failed to release job lock: {}", e),
+                source: Some(Box::new(e)),
             })?;
 
         Ok(result == 1)
@@ -673,7 +902,7 @@ impl Storage for RedisStorage {
         &self,
         worker_id: &str,
         limit: Option<usize>,
-        _queues: Option<&[String]>,
+        queues: Option<&[String]>,
     ) -> Result<Vec<Job>, StorageError> {
         let mut jobs = Vec::new();
         let fetch_limit = limit.unwrap_or(10).min(50); // Cap at 50 jobs for Redis
@@ -681,7 +910,7 @@ impl Storage for RedisStorage {
         // For Redis, fetch jobs one by one to ensure proper atomic locking
         // This could be optimized with a more complex Lua script if needed
         for _ in 0..fetch_limit {
-            match self.fetch_and_lock_job(worker_id, _queues).await? {
+            match self.fetch_and_lock_job(worker_id, queues).await? {
                 Some(job) => jobs.push(job),
                 None => break, // No more available jobs
             }

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -36,13 +36,19 @@ pub struct Settings {
 impl Settings {
     /// Load settings from environment variables
     pub fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
+        // The signature is fallible — propagate via `?` rather than
+        // `expect`. A panic here was a footgun for any caller that
+        // enabled the `postgres`/`redis` feature without exporting the
+        // matching URL.
         #[cfg(feature = "postgres")]
-        let database_url = Some(env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
+        let database_url =
+            Some(env::var("DATABASE_URL").map_err(|e| format!("DATABASE_URL must be set: {}", e))?);
         #[cfg(not(feature = "postgres"))]
         let database_url = None;
 
         #[cfg(feature = "redis")]
-        let redis_url = Some(env::var("REDIS_URL").expect("REDIS_URL must be set"));
+        let redis_url =
+            Some(env::var("REDIS_URL").map_err(|e| format!("REDIS_URL must be set: {}", e))?);
         #[cfg(not(feature = "redis"))]
         let redis_url = None;
 

--- a/src/storage/test_locking.rs
+++ b/src/storage/test_locking.rs
@@ -330,7 +330,12 @@ async fn test_redis_lock_management() {
         return;
     };
 
-    let job_id = "redis_lock_test";
+    // Unique job_id so a parallel test (or a stale lock from a prior
+    // failed run) sharing the same default key_prefix can't pre-poison
+    // `qml:lock:redis_lock_test` and break the "worker 1 acquires"
+    // assertion.
+    let job_id_owned = format!("redis_lock_test_{}", uuid::Uuid::new_v4());
+    let job_id = job_id_owned.as_str();
     let worker1 = "redis_worker_1";
     let worker2 = "redis_worker_2";
 
@@ -371,11 +376,18 @@ async fn test_postgres_race_condition_prevention() {
 
     let storage = Arc::new(storage);
 
-    // Create a single job
-    let job = create_test_job("postgres_race_test");
+    // Scope the test to a unique queue. Multiple tests share the same
+    // postgres database (and table), so leftover Enqueued rows from a
+    // previous run would let several workers grab "different" jobs and
+    // break the "exactly one worker fetches it" assertion.
+    let queue = format!("pg-race-{}", uuid::Uuid::new_v4());
+    let mut job = create_test_job("postgres_race_test");
+    job.queue = queue.clone();
+    job.state = crate::core::JobState::enqueued(&queue);
     storage.enqueue(&job).await.unwrap();
 
-    // Multiple workers try to fetch the same job
+    // Multiple workers try to fetch the same job, each scoped to the
+    // single test queue.
     let num_workers = 8;
     let success_count = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::new();
@@ -384,9 +396,13 @@ async fn test_postgres_race_condition_prevention() {
         let storage_clone = Arc::clone(&storage);
         let success_count_clone = Arc::clone(&success_count);
         let worker_id = format!("pg_worker_{}", i);
+        let queues = vec![queue.clone()];
 
         let handle = tokio::spawn(async move {
-            match storage_clone.fetch_and_lock_job(&worker_id, None).await {
+            match storage_clone
+                .fetch_and_lock_job(&worker_id, Some(&queues))
+                .await
+            {
                 Ok(Some(_job)) => {
                     success_count_clone.fetch_add(1, Ordering::SeqCst);
                     true
@@ -420,7 +436,17 @@ async fn test_postgres_lock_table() {
         return;
     };
 
-    let job_id = "postgres_lock_test";
+    // The Postgres backend's `try_acquire_job_lock` is a row-level lock on
+    // an existing `qml_jobs` row (it UPDATEs `locked_by`/`lock_expires_at`
+    // on the job itself). It cannot lock an arbitrary id — the row must
+    // exist first. Enqueue a real job to grab a real id; the previous
+    // version of this test passed a free-form string that wasn't even a
+    // UUID, but only "passed" while DATABASE_URL was unset and
+    // `create_postgres_storage` returned None.
+    let job = create_test_job("postgres_lock_test");
+    storage.enqueue(&job).await.unwrap();
+    let job_id_owned = job.id.clone();
+    let job_id = job_id_owned.as_str();
     let worker1 = "pg_worker_1";
     let worker2 = "pg_worker_2";
 

--- a/tests/claim_due_jobs_test.rs
+++ b/tests/claim_due_jobs_test.rs
@@ -1,0 +1,237 @@
+//! Cross-backend integration tests for the atomic claim methods on
+//! `Storage`: `claim_due_scheduled_jobs` and `claim_due_retry_jobs`.
+//!
+//! These methods replace the old "fetch then update" pattern in
+//! `JobScheduler` with an in-storage atomic transition so two schedulers
+//! against the same backend can't both promote the same job. The test
+//! contract:
+//!
+//! 1. A claim returns the due jobs already transitioned to `Enqueued`.
+//! 2. A second claim observes none of the already-claimed jobs.
+//! 3. Future-dated jobs are never claimed.
+//!
+//! Tests for Redis/Postgres self-skip when the backend service is not
+//! reachable (`REDIS_URL`, `DATABASE_URL`/`POSTGRES_URL`).
+
+use std::env;
+
+use chrono::{Duration, Utc};
+use qml_rs::core::{Job, JobState};
+use qml_rs::storage::{MemoryStorage, Storage};
+
+#[cfg(feature = "postgres")]
+fn database_url() -> Option<String> {
+    env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::var("POSTGRES_URL").ok())
+}
+
+#[cfg(feature = "redis")]
+fn redis_url() -> Option<String> {
+    env::var("REDIS_URL").ok()
+}
+
+async fn exercise_claim_due_scheduled(storage: &dyn Storage) {
+    let mut due_ids = Vec::new();
+    for _ in 0..3 {
+        let mut job = Job::new("claim_due_test", serde_json::json!(null));
+        job.set_state(JobState::scheduled(
+            Utc::now() - Duration::seconds(5),
+            "past",
+        ))
+        .unwrap();
+        due_ids.push(job.id.clone());
+        storage.enqueue(&job).await.unwrap();
+    }
+
+    // Future-dated job — must never be claimed.
+    let mut future = Job::new("claim_due_test_future", serde_json::json!(null));
+    future
+        .set_state(JobState::scheduled(
+            Utc::now() + Duration::hours(1),
+            "future",
+        ))
+        .unwrap();
+    let future_id = future.id.clone();
+    storage.enqueue(&future).await.unwrap();
+
+    let claimed = storage
+        .claim_due_scheduled_jobs(Utc::now(), 100)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 3, "all 3 due jobs must be claimed");
+    for job in &claimed {
+        assert!(
+            matches!(job.state, JobState::Enqueued { .. }),
+            "claim returns jobs already in Enqueued state, got {:?}",
+            job.state
+        );
+    }
+
+    // Idempotence: second claim returns empty — atomicity contract.
+    let again = storage
+        .claim_due_scheduled_jobs(Utc::now(), 100)
+        .await
+        .unwrap();
+    assert!(
+        again.is_empty(),
+        "second claim must not re-pick already-promoted jobs"
+    );
+
+    // Future job is still Scheduled.
+    let future_now = storage.get(&future_id).await.unwrap().unwrap();
+    assert!(
+        matches!(future_now.state, JobState::Scheduled { .. }),
+        "future-dated job must remain Scheduled"
+    );
+
+    // The 3 claimed jobs are now Enqueued in storage.
+    for id in &due_ids {
+        let job = storage.get(id).await.unwrap().unwrap();
+        assert!(matches!(job.state, JobState::Enqueued { .. }));
+    }
+}
+
+async fn exercise_claim_due_retry(storage: &dyn Storage) {
+    // AwaitingRetry is only reachable via Processing → AwaitingRetry, so
+    // bypass set_state validation and assign directly.
+    let mut due_ids = Vec::new();
+    for _ in 0..2 {
+        let mut job = Job::new("claim_retry_test", serde_json::json!(null));
+        job.state = JobState::awaiting_retry(Utc::now() - Duration::seconds(5), "past");
+        due_ids.push(job.id.clone());
+        storage.enqueue(&job).await.unwrap();
+    }
+
+    let mut future = Job::new("claim_retry_test_future", serde_json::json!(null));
+    future.state = JobState::awaiting_retry(Utc::now() + Duration::hours(1), "future");
+    let future_id = future.id.clone();
+    storage.enqueue(&future).await.unwrap();
+
+    let claimed = storage.claim_due_retry_jobs(Utc::now(), 100).await.unwrap();
+    assert_eq!(claimed.len(), 2);
+    for job in &claimed {
+        assert!(matches!(job.state, JobState::Enqueued { .. }));
+    }
+
+    let again = storage.claim_due_retry_jobs(Utc::now(), 100).await.unwrap();
+    assert!(again.is_empty());
+
+    let future_now = storage.get(&future_id).await.unwrap().unwrap();
+    assert!(matches!(future_now.state, JobState::AwaitingRetry { .. }));
+
+    for id in &due_ids {
+        let job = storage.get(id).await.unwrap().unwrap();
+        assert!(matches!(job.state, JobState::Enqueued { .. }));
+    }
+}
+
+#[tokio::test]
+async fn memory_claim_due_scheduled() {
+    let storage = MemoryStorage::new();
+    exercise_claim_due_scheduled(&storage).await;
+}
+
+#[tokio::test]
+async fn memory_claim_due_retry() {
+    let storage = MemoryStorage::new();
+    exercise_claim_due_retry(&storage).await;
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_claim_due_scheduled() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis claim_due_scheduled test");
+        return;
+    };
+
+    let prefix = format!("cds-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis claim_due_scheduled test: {e}");
+            return;
+        }
+    };
+
+    exercise_claim_due_scheduled(&storage).await;
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_claim_due_retry() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis claim_due_retry test");
+        return;
+    };
+
+    let prefix = format!("cdr-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis claim_due_retry test: {e}");
+            return;
+        }
+    };
+
+    exercise_claim_due_retry(&storage).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_claim_due_scheduled() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL/POSTGRES_URL not set; skipping postgres claim_due_scheduled");
+        return;
+    };
+
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres claim_due_scheduled test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres claim_due_scheduled test: migrate failed: {e}");
+        return;
+    }
+
+    exercise_claim_due_scheduled(&storage).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_claim_due_retry() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL/POSTGRES_URL not set; skipping postgres claim_due_retry");
+        return;
+    };
+
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres claim_due_retry test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres claim_due_retry test: migrate failed: {e}");
+        return;
+    }
+
+    exercise_claim_due_retry(&storage).await;
+}

--- a/tests/config_panic_fix_test.rs
+++ b/tests/config_panic_fix_test.rs
@@ -22,13 +22,18 @@ fn test_memory_config_no_panic() {
 fn test_redis_config_no_panic() {
     use qml_rs::storage::RedisConfig;
 
-    // This should NOT panic even without REDIS_URL environment variable
+    // This should NOT panic even without REDIS_URL environment variable.
+    // Compute the expected URL the same way `Default::default()` does so
+    // the test passes whether or not REDIS_URL is exported in the
+    // surrounding environment.
+    let expected_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
     let redis_config = RedisConfig::default();
-    assert_eq!(redis_config.url, "redis://localhost:6379");
+    assert_eq!(redis_config.url, expected_url);
     assert_eq!(redis_config.pool_size, 10);
     assert_eq!(redis_config.key_prefix, "qml");
     println!(
-        "✅ RedisConfig::default() works without REDIS_URL: {}",
+        "✅ RedisConfig::default() works: url = {}",
         redis_config.url
     );
 }
@@ -38,16 +43,17 @@ fn test_redis_config_no_panic() {
 fn test_postgres_config_no_panic() {
     use qml_rs::storage::PostgresConfig;
 
-    // This should NOT panic even without DATABASE_URL environment variable
+    // This should NOT panic even without DATABASE_URL environment
+    // variable. Mirror the env-aware default so the test is stable
+    // under both `cargo test` and `DATABASE_URL=… cargo test`.
+    let expected_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgresql://postgres:password@localhost:5432/qml".to_string());
     let postgres_config = PostgresConfig::default();
-    assert_eq!(
-        postgres_config.database_url,
-        "postgresql://postgres:password@localhost:5432/qml"
-    );
+    assert_eq!(postgres_config.database_url, expected_url);
     assert_eq!(postgres_config.max_connections, 20);
     assert_eq!(postgres_config.schema_name, "qml");
     println!(
-        "✅ PostgresConfig::default() works without DATABASE_URL: {}",
+        "✅ PostgresConfig::default() works: url = {}",
         postgres_config.database_url
     );
 }

--- a/tests/dashboard_shutdown_test.rs
+++ b/tests/dashboard_shutdown_test.rs
@@ -1,0 +1,90 @@
+//! Tests for DashboardServer's graceful-shutdown contract (review I13).
+//!
+//! Before this work, DashboardServer::start ran `axum::serve(...).await`
+//! with no shutdown source, and `WebSocketManager::start_periodic_updates`
+//! was a detached `tokio::spawn` with no JoinHandle. Embedding the
+//! dashboard in any larger app's shutdown sequence was effectively
+//! impossible.
+
+#![cfg(feature = "dashboard")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use qml_rs::storage::MemoryStorage;
+use qml_rs::{DashboardConfig, DashboardServer};
+
+/// Pick a deterministically free localhost port for tests. Binding to
+/// port 0 in OS terms gives us one no other test will collide with.
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+#[tokio::test]
+async fn shutdown_token_fires_returns_start_cleanly() {
+    let storage = Arc::new(MemoryStorage::new());
+    let port = free_port().await;
+    let config = DashboardConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        statistics_update_interval: 60,
+        auth: None,
+        #[cfg(feature = "metrics")]
+        metrics: None,
+    };
+
+    let server = Arc::new(DashboardServer::new(storage, config));
+    let server_clone = Arc::clone(&server);
+    let join = tokio::spawn(async move { server_clone.start().await });
+
+    // Give the server a beat to bind the socket.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Trigger shutdown.
+    server.shutdown();
+
+    // start() must return promptly (not block until the next periodic tick
+    // 60s away or until external traffic). 5s is generous; on a healthy
+    // machine this completes in well under a second.
+    let outcome = tokio::time::timeout(Duration::from_secs(5), join)
+        .await
+        .expect("DashboardServer::start did not return within 5s of shutdown")
+        .expect("join handle panicked");
+
+    outcome.expect("DashboardServer::start returned an error");
+}
+
+#[tokio::test]
+async fn external_cancellation_token_propagates() {
+    use tokio_util::sync::CancellationToken;
+
+    let storage = Arc::new(MemoryStorage::new());
+    let port = free_port().await;
+    let config = DashboardConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        statistics_update_interval: 60,
+        auth: None,
+        #[cfg(feature = "metrics")]
+        metrics: None,
+    };
+
+    let server = Arc::new(DashboardServer::new(storage, config));
+    let external_cancel = CancellationToken::new();
+    let server_clone = Arc::clone(&server);
+    let cancel_clone = external_cancel.clone();
+    let join = tokio::spawn(async move { server_clone.run_until_cancelled(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    external_cancel.cancel();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), join)
+        .await
+        .expect("run_until_cancelled did not return within 5s of external cancel")
+        .expect("join handle panicked");
+
+    outcome.expect("run_until_cancelled returned an error");
+}

--- a/tests/dashboard_shutdown_test.rs
+++ b/tests/dashboard_shutdown_test.rs
@@ -8,10 +8,13 @@
 
 #![cfg(feature = "dashboard")]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use qml_rs::storage::MemoryStorage;
+use async_trait::async_trait;
+use qml_rs::core::{Job, JobStateKind};
+use qml_rs::storage::{MemoryStorage, MonitoringApi, StorageError};
 use qml_rs::{DashboardConfig, DashboardServer};
 
 /// Pick a deterministically free localhost port for tests. Binding to
@@ -87,4 +90,85 @@ async fn external_cancellation_token_propagates() {
         .expect("join handle panicked");
 
     outcome.expect("run_until_cancelled returned an error");
+}
+
+/// A `MonitoringApi` that hangs forever on `list` / `get_job_counts`.
+/// Stand-in for an unhealthy backend so the test can prove
+/// [`DashboardServer::run_until_cancelled`] still unblocks even when
+/// the periodic statistics task is wedged inside a storage call.
+struct HangingMonitoringApi;
+
+#[async_trait]
+impl MonitoringApi for HangingMonitoringApi {
+    async fn get(&self, _job_id: &str) -> Result<Option<Job>, StorageError> {
+        std::future::pending().await
+    }
+    async fn update(&self, _job: &Job) -> Result<(), StorageError> {
+        std::future::pending().await
+    }
+    async fn update_if_state(
+        &self,
+        _job: &Job,
+        _expected: JobStateKind,
+    ) -> Result<bool, StorageError> {
+        std::future::pending().await
+    }
+    async fn delete(&self, _job_id: &str) -> Result<bool, StorageError> {
+        std::future::pending().await
+    }
+    async fn list(
+        &self,
+        _state_filter: Option<JobStateKind>,
+        _limit: Option<usize>,
+        _offset: Option<usize>,
+    ) -> Result<Vec<Job>, StorageError> {
+        std::future::pending().await
+    }
+    async fn get_job_counts(&self) -> Result<HashMap<JobStateKind, usize>, StorageError> {
+        std::future::pending().await
+    }
+}
+
+#[tokio::test]
+async fn shutdown_returns_even_when_periodic_task_is_wedged() {
+    // Reviewer concern (PR #23): `periodic_handle.await` had no timeout,
+    // so a hung `get_server_statistics()` could block the entire
+    // shutdown sequence. This test feeds the dashboard a fake backend
+    // that never returns from any storage call. Once the periodic task
+    // is stuck inside a hanging `list()`, cancelling the dashboard must
+    // still return within the 5-second timeout (plus a small margin).
+    let storage: Arc<dyn MonitoringApi> = Arc::new(HangingMonitoringApi);
+    let port = free_port().await;
+    let config = DashboardConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        // Tight interval so the periodic task hits the hanging storage
+        // call before we trigger shutdown.
+        statistics_update_interval: 1,
+        auth: None,
+        #[cfg(feature = "metrics")]
+        metrics: None,
+    };
+
+    let server = Arc::new(DashboardServer::new(storage, config));
+    let server_clone = Arc::clone(&server);
+    let join = tokio::spawn(async move { server_clone.start().await });
+
+    // Wait long enough for the periodic task to be wedged inside the
+    // first `get_server_statistics` call.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+    server.shutdown();
+
+    // The internal timeout is 5s; allow ~2s of margin for runtime
+    // scheduling and the abort-then-await path.
+    let outcome = tokio::time::timeout(Duration::from_secs(7), join)
+        .await
+        .expect(
+            "DashboardServer::start blocked for >7s after shutdown despite \
+             a hung periodic task — periodic_handle.await timeout missing?",
+        )
+        .expect("join handle panicked");
+
+    outcome.expect("DashboardServer::start returned an error");
 }

--- a/tests/processing_recovery_test.rs
+++ b/tests/processing_recovery_test.rs
@@ -1,0 +1,137 @@
+//! Cross-backend integration tests for the Processing → Enqueued
+//! recovery primitives — `Storage::requeue_stranded_jobs` and
+//! `Storage::reclaim_jobs_from_server`.
+//!
+//! These run on `BackgroundJobServer::start` (stranded sweep) and the
+//! `HeartbeatWorker` (dead-peer reclaim) respectively. Both must:
+//!
+//! 1. Match only `Processing` rows whose `state_data` field passes the
+//!    filter (started_at older than the cutoff for stranded; server_name
+//!    matching the dead peer for reclaim).
+//! 2. Synthesize a fresh `Enqueued` `state_data` that round-trips
+//!    through `serde_json` back into a valid `JobState::Enqueued`. An
+//!    earlier postgres revision produced JSON that didn't deserialize
+//!    because the variant key (`"Enqueued"`) was missing — and a separate
+//!    revision used a hand-rolled `to_char` timestamp mask sensitive to
+//!    format-string drift.
+//!
+//! Postgres-only: the JSON shape differences only matter when the
+//! storage engine synthesizes the JSON itself. Memory and Redis assemble
+//! `JobState` in Rust and round-trip through serde naturally.
+
+#![cfg(feature = "postgres")]
+
+use std::env;
+
+use chrono::{Duration, Utc};
+use qml_rs::core::{Job, JobState};
+use qml_rs::storage::{MonitoringApi, PostgresConfig, PostgresStorage, Storage};
+
+fn database_url() -> Option<String> {
+    env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::var("POSTGRES_URL").ok())
+}
+
+async fn fresh_storage() -> Option<PostgresStorage> {
+    let url = database_url()?;
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = PostgresStorage::new(config).await.ok()?;
+    storage.migrate().await.ok()?;
+    Some(storage)
+}
+
+fn processing_job_for(server_name: &str, started_at: chrono::DateTime<Utc>) -> Job {
+    let mut job = Job::new("recovery_test", serde_json::json!(null));
+    job.queue = format!("recov-{}", uuid::Uuid::new_v4());
+    job.state = JobState::Processing {
+        worker_id: "w1".into(),
+        started_at,
+        server_name: server_name.into(),
+    };
+    job
+}
+
+#[tokio::test]
+async fn requeue_stranded_jobs_round_trips_into_valid_enqueued() {
+    let Some(storage) = fresh_storage().await else {
+        eprintln!("DATABASE_URL not set; skipping stranded round-trip test");
+        return;
+    };
+
+    // Stale (1h ago) — must be recovered.
+    let stale = processing_job_for("dead-srv", Utc::now() - Duration::hours(1));
+    let stale_id = stale.id.clone();
+    storage.enqueue(&stale).await.unwrap();
+
+    // Fresh (1s ago) — must NOT be recovered.
+    let fresh = processing_job_for("live-srv", Utc::now() - Duration::seconds(1));
+    let fresh_id = fresh.id.clone();
+    storage.enqueue(&fresh).await.unwrap();
+
+    let recovered = storage
+        .requeue_stranded_jobs(Utc::now() - Duration::minutes(5))
+        .await
+        .unwrap();
+    assert_eq!(recovered, 1, "exactly the stale job should be recovered");
+
+    // The stale job must read back via the regular `get` path — i.e. its
+    // newly-synthesized `state_data` must be valid externally-tagged
+    // JobState. A bug in the SQL would surface here as a deserialization
+    // error, not a missed assertion.
+    let recovered_job = storage
+        .get(&stale_id)
+        .await
+        .expect("get must not fail")
+        .expect("recovered job must still exist");
+    assert!(
+        matches!(recovered_job.state, JobState::Enqueued { .. }),
+        "expected Enqueued, got {:?}",
+        recovered_job.state
+    );
+    if let JobState::Enqueued { queue, .. } = &recovered_job.state {
+        assert_eq!(
+            queue, &recovered_job.queue,
+            "queue field should match the row"
+        );
+    }
+
+    // Fresh job is still Processing.
+    let fresh_now = storage.get(&fresh_id).await.unwrap().unwrap();
+    assert!(matches!(fresh_now.state, JobState::Processing { .. }));
+}
+
+#[tokio::test]
+async fn reclaim_jobs_from_server_round_trips_into_valid_enqueued() {
+    let Some(storage) = fresh_storage().await else {
+        eprintln!("DATABASE_URL not set; skipping reclaim round-trip test");
+        return;
+    };
+
+    let dead_peer = format!("dead-{}", uuid::Uuid::new_v4());
+    let other_peer = format!("alive-{}", uuid::Uuid::new_v4());
+
+    let dead_job = processing_job_for(&dead_peer, Utc::now() - Duration::seconds(1));
+    let dead_id = dead_job.id.clone();
+    storage.enqueue(&dead_job).await.unwrap();
+
+    let live_job = processing_job_for(&other_peer, Utc::now() - Duration::seconds(1));
+    let live_id = live_job.id.clone();
+    storage.enqueue(&live_job).await.unwrap();
+
+    let reclaimed = storage.reclaim_jobs_from_server(&dead_peer).await.unwrap();
+    assert_eq!(
+        reclaimed, 1,
+        "only jobs owned by the dead peer should be reclaimed"
+    );
+
+    let dead_now = storage.get(&dead_id).await.unwrap().unwrap();
+    assert!(
+        matches!(dead_now.state, JobState::Enqueued { .. }),
+        "expected Enqueued, got {:?}",
+        dead_now.state
+    );
+
+    let live_now = storage.get(&live_id).await.unwrap().unwrap();
+    assert!(matches!(live_now.state, JobState::Processing { .. }));
+}

--- a/tests/queue_filter_test.rs
+++ b/tests/queue_filter_test.rs
@@ -1,0 +1,240 @@
+//! Cross-backend integration tests for the queue filter on
+//! `Storage::fetch_and_lock_job`.
+//!
+//! Every backend's `fetch_and_lock_job(worker_id, queues)` must honor the
+//! `queues` filter: a worker scoped to queue `A` must not receive jobs in
+//! queue `B`. This contract was previously unenforced — the Redis backend
+//! silently ignored the parameter.
+//!
+//! Tests for Redis/Postgres self-skip when the backend service is not
+//! reachable (`REDIS_URL`, `DATABASE_URL`/`POSTGRES_URL`).
+
+use std::env;
+
+use qml_rs::core::{Job, JobState};
+use qml_rs::storage::{MemoryStorage, Storage};
+
+#[cfg(feature = "postgres")]
+fn database_url() -> Option<String> {
+    env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::var("POSTGRES_URL").ok())
+}
+
+#[cfg(feature = "redis")]
+fn redis_url() -> Option<String> {
+    env::var("REDIS_URL").ok()
+}
+
+fn job_in(queue: &str) -> Job {
+    let mut job = Job::new("queue_filter_test", serde_json::json!(null));
+    job.queue = queue.to_string();
+    job.state = JobState::enqueued(queue);
+    job
+}
+
+/// Enqueues jobs across two queues and asserts:
+/// 1. A worker filtered to one queue only receives jobs from that queue.
+/// 2. A worker filtered to the other queue only receives jobs from that queue.
+/// 3. After all matching jobs are claimed, further calls return `None`.
+async fn exercise_queue_filter(storage: &dyn Storage, queue_a: &str, queue_b: &str) {
+    // 3 in queue_a, 2 in queue_b.
+    let mut a_ids = Vec::new();
+    for _ in 0..3 {
+        let j = job_in(queue_a);
+        a_ids.push(j.id.clone());
+        storage.enqueue(&j).await.unwrap();
+    }
+    let mut b_ids = Vec::new();
+    for _ in 0..2 {
+        let j = job_in(queue_b);
+        b_ids.push(j.id.clone());
+        storage.enqueue(&j).await.unwrap();
+    }
+
+    let only_a = vec![queue_a.to_string()];
+    let only_b = vec![queue_b.to_string()];
+
+    // Worker scoped to queue_a must only see queue_a jobs.
+    let mut claimed_a = 0;
+    while let Some(job) = storage
+        .fetch_and_lock_job("worker-a", Some(&only_a))
+        .await
+        .unwrap()
+    {
+        assert_eq!(
+            job.queue, queue_a,
+            "worker scoped to {queue_a} must not receive {} job",
+            job.queue
+        );
+        claimed_a += 1;
+        if claimed_a > 10 {
+            panic!("runaway loop fetching {queue_a}");
+        }
+    }
+    assert_eq!(
+        claimed_a, 3,
+        "worker scoped to {queue_a} should claim all 3 {queue_a} jobs"
+    );
+
+    // Worker scoped to queue_b must only see queue_b jobs (queue_a is now drained).
+    let mut claimed_b = 0;
+    while let Some(job) = storage
+        .fetch_and_lock_job("worker-b", Some(&only_b))
+        .await
+        .unwrap()
+    {
+        assert_eq!(
+            job.queue, queue_b,
+            "worker scoped to {queue_b} must not receive {} job",
+            job.queue
+        );
+        claimed_b += 1;
+        if claimed_b > 10 {
+            panic!("runaway loop fetching {queue_b}");
+        }
+    }
+    assert_eq!(
+        claimed_b, 2,
+        "worker scoped to {queue_b} should claim all 2 {queue_b} jobs"
+    );
+}
+
+/// Enqueue one queue_a and one queue_b, then claim with no filter. Must
+/// return both (in some order) before returning None.
+async fn exercise_no_filter(storage: &dyn Storage, queue_a: &str, queue_b: &str) {
+    storage.enqueue(&job_in(queue_a)).await.unwrap();
+    storage.enqueue(&job_in(queue_b)).await.unwrap();
+
+    let mut seen = std::collections::HashSet::new();
+    while let Some(job) = storage.fetch_and_lock_job("worker", None).await.unwrap() {
+        seen.insert(job.queue);
+        if seen.len() > 5 {
+            panic!("runaway loop in no-filter fetch");
+        }
+    }
+    assert!(
+        seen.contains(queue_a) && seen.contains(queue_b),
+        "no-filter worker should receive jobs from both queues, got {seen:?}"
+    );
+}
+
+#[tokio::test]
+async fn memory_queue_filter_isolates_queues() {
+    let storage = MemoryStorage::new();
+    exercise_queue_filter(&storage, "memq-a", "memq-b").await;
+}
+
+#[tokio::test]
+async fn memory_queue_filter_no_filter_returns_all() {
+    let storage = MemoryStorage::new();
+    exercise_no_filter(&storage, "memnf-a", "memnf-b").await;
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_queue_filter_isolates_queues() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis queue filter test");
+        return;
+    };
+
+    // Unique key prefix so this test doesn't collide with the wider suite
+    // when the same Redis instance is reused.
+    let prefix = format!("qf-iso-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis queue filter test: {e}");
+            return;
+        }
+    };
+
+    exercise_queue_filter(&storage, "redq-a", "redq-b").await;
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_queue_filter_no_filter_returns_all() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis queue no-filter test");
+        return;
+    };
+
+    let prefix = format!("qf-nofilter-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis queue no-filter test: {e}");
+            return;
+        }
+    };
+
+    exercise_no_filter(&storage, "rednf-a", "rednf-b").await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_queue_filter_isolates_queues() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL/POSTGRES_URL not set; skipping postgres queue filter test");
+        return;
+    };
+
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres queue filter test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres queue filter test: migrate failed: {e}");
+        return;
+    }
+
+    // Unique queue names so concurrent test runs against the same database
+    // can't observe each other's jobs.
+    let suffix = uuid::Uuid::new_v4();
+    let qa = format!("pgq-a-{suffix}");
+    let qb = format!("pgq-b-{suffix}");
+    exercise_queue_filter(&storage, &qa, &qb).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_queue_filter_no_filter_returns_all() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL/POSTGRES_URL not set; skipping postgres queue no-filter test");
+        return;
+    };
+
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres queue no-filter test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres queue no-filter test: migrate failed: {e}");
+        return;
+    }
+
+    let suffix = uuid::Uuid::new_v4();
+    let qa = format!("pgnf-a-{suffix}");
+    let qb = format!("pgnf-b-{suffix}");
+    exercise_no_filter(&storage, &qa, &qb).await;
+}

--- a/tests/storage_integration_tests.rs
+++ b/tests/storage_integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, Utc};
 use qml_rs::{
-    Job, JobState, MonitoringApi, Storage,
+    Job, JobState, JobStateKind, MonitoringApi, Storage,
     storage::{MemoryConfig, StorageConfig, StorageInstance},
 };
 
@@ -101,9 +101,8 @@ async fn test_storage_interface(storage: &StorageInstance) {
     assert_eq!(all_jobs.len(), 3);
 
     // Test filtering by state
-    let enqueued_state = JobState::enqueued("default");
     let enqueued_jobs = storage
-        .list(Some(&enqueued_state), None, None)
+        .list(Some(JobStateKind::Enqueued), None, None)
         .await
         .unwrap();
     assert_eq!(enqueued_jobs.len(), 1);

--- a/tests/update_if_state_test.rs
+++ b/tests/update_if_state_test.rs
@@ -1,0 +1,147 @@
+//! Cross-backend integration tests for `MonitoringApi::update_if_state` —
+//! the compare-and-swap variant of `update`.
+//!
+//! Contract:
+//! 1. When the persisted state matches `expected`, the update is applied
+//!    and `Ok(true)` is returned.
+//! 2. When the persisted state has moved on (e.g. a worker picked the job
+//!    up after a dashboard read), the update is *not* applied and
+//!    `Ok(false)` is returned.
+//! 3. When no row exists for the id, `Err(JobNotFound)` is returned.
+//!
+//! This is the primitive that protects the dashboard retry path from
+//! stomping on a `Processing` state — without it, a slow second retry can
+//! overwrite a `Processing` state that a worker had taken on after the
+//! first retry. Verified across all three backends.
+
+use std::env;
+
+use qml_rs::core::{Job, JobState, JobStateKind};
+use qml_rs::storage::{MemoryStorage, MonitoringApi, Storage, StorageError};
+
+#[cfg(feature = "postgres")]
+fn database_url() -> Option<String> {
+    env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::var("POSTGRES_URL").ok())
+}
+
+#[cfg(feature = "redis")]
+fn redis_url() -> Option<String> {
+    env::var("REDIS_URL").ok()
+}
+
+/// Run the CAS contract checks against any backend implementing both
+/// `Storage` (for the initial enqueue) and `MonitoringApi` (for the CAS
+/// operation under test).
+async fn exercise_cas<S: Storage + MonitoringApi + ?Sized>(storage: &S) {
+    // Job 1: starts Failed (the canonical "retry me" state). CAS with
+    // expected=Failed → success.
+    let mut failed = Job::new("cas_test", serde_json::json!(null));
+    failed.state = JobState::Failed {
+        exception: "boom".into(),
+        failed_at: chrono::Utc::now(),
+        stack_trace: None,
+    };
+    let failed_id = failed.id.clone();
+    storage.enqueue(&failed).await.unwrap();
+
+    let mut promoted = failed.clone();
+    promoted.state = JobState::enqueued(&promoted.queue);
+    let applied = storage
+        .update_if_state(&promoted, JobStateKind::Failed)
+        .await
+        .unwrap();
+    assert!(applied, "first retry should apply on a Failed job");
+
+    let after_first = storage.get(&failed_id).await.unwrap().unwrap();
+    assert!(matches!(after_first.state, JobState::Enqueued { .. }));
+
+    // Simulate a worker now picking up the (Enqueued) job.
+    let mut working = after_first.clone();
+    working.state = JobState::processing("worker-1", "server-1");
+    storage.update(&working).await.unwrap();
+
+    // A second slow retry holds a stale `expected = Failed` view — must
+    // be rejected, leaving the Processing state intact.
+    let mut second_retry = working.clone();
+    second_retry.state = JobState::enqueued(&second_retry.queue);
+    let stomped = storage
+        .update_if_state(&second_retry, JobStateKind::Failed)
+        .await
+        .unwrap();
+    assert!(
+        !stomped,
+        "second retry must NOT apply when the persisted state has moved on"
+    );
+
+    let after_second = storage.get(&failed_id).await.unwrap().unwrap();
+    assert!(
+        matches!(after_second.state, JobState::Processing { .. }),
+        "Processing state must be preserved against stale CAS"
+    );
+
+    // JobNotFound for an absent id.
+    let mut absent = Job::new("cas_test_absent", serde_json::json!(null));
+    absent.state = JobState::enqueued(&absent.queue);
+    let err = storage
+        .update_if_state(&absent, JobStateKind::Failed)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, StorageError::JobNotFound { .. }),
+        "absent id must return JobNotFound, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn memory_update_if_state_cas_contract() {
+    let storage = MemoryStorage::new();
+    exercise_cas(&storage).await;
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_update_if_state_cas_contract() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis CAS test");
+        return;
+    };
+    let prefix = format!("uis-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis CAS test: {e}");
+            return;
+        }
+    };
+    exercise_cas(&storage).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_update_if_state_cas_contract() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL not set; skipping postgres CAS test");
+        return;
+    };
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres CAS test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres CAS test: migrate failed: {e}");
+        return;
+    }
+    exercise_cas(&storage).await;
+}


### PR DESCRIPTION
First batch from a principal-engineer code review pass over the crate. Each commit closes a specific reviewer finding; bundled here because they share files and several depend on each other for compile cleanliness.

## Critical correctness fixes (silent prod bugs)

- **fix: code review batch — Redis correctness, error chains, scheduler atomicity** (`a283a29`) — Redis `fetch_and_lock_job` was completely broken in production. The Lua script had five entangled bugs: `_queues` filter ignored, wrong key namespace (`qml:job:` vs `qml:jobs:`), wrong ordering (`ZRANGEBYSCORE` asc instead of `ZREVRANGEBYSCORE` desc), hardcoded `qml:` prefix, and counter math that decremented both `enqueued` and `awaiting_retry` regardless of source state. Plus a sixth: timestamps written as raw millis where chrono expects RFC3339. Workers never picked up Redis-backed jobs. Latent because integration tests skip without `REDIS_URL` set. Same commit also adds atomic claim-and-transition primitives (`claim_due_scheduled_jobs`, `claim_due_retry_jobs`) to replace the racy fetch+update flow in `JobScheduler`, and pulls source-chain plumbing through 50+ `StorageError` call sites.

- **fix(postgres): correct externally-tagged JSON paths and consolidate Processing→Enqueued recovery** (`be72da7`) — Same shape of bug on the Postgres side. Every time-predicate query was reading `state_data->>'enqueue_at'` at the top level, but `JobState` is externally tagged so the actual path is `state_data->'Scheduled'->>'enqueue_at'`. NULL extraction made every predicate evaluate false: `fetch_due_*`, `claim_due_*`, `requeue_stranded_jobs`, `reclaim_jobs_from_server`, and the scheduled/retry branches of `get_available_jobs` all silently returned nothing. Postgres-backed scheduler/retry/recovery was never functional. Also fixed: `state_data` synthesis was missing the variant key wrapper (`{"Enqueued": {...}}`) so writes didn't deserialize back; consolidated the two `to_char` UPDATEs behind one helper using `to_jsonb(NOW())`.

- **fix(redis): make update atomic via Lua to close TOCTOU and counter drift** (`edf7b63`) — `RedisStorage::update` was `get()` + `set()` plus 5 non-transactional index commands. Two concurrent updaters reading the same `old_state` both decremented the same counter (drift); a reader between SET and the index commands could see inconsistent state. Single Lua script now.

- **fix(redis): drop native key TTL; rely on CleanupWorker sweep** (`b5c76da`) — Native Redis EXPIRE on Succeeded/Failed jobs raced the cross-backend `CleanupWorker`. When the native TTL won, the job key vanished but the index entries (`qml:state:succeeded`, `qml:all`, `qml:counts`) leaked forever. Single source of truth now.

## Substantive features

- **feat(storage): add update_if_state CAS variant; gate dashboard retry behind it** (`774271f`) — `MonitoringApi::update_if_state(job, expected: JobStateKind) -> Result<bool, StorageError>`. The dashboard "retry" button used to be a blind read-then-write that could stomp a worker's `Processing` state when two retries raced. Now applies only if the persisted state still matches `expected`; returns `Ok(false)` on stomp-avoidance.

- **feat(dashboard): graceful shutdown and bounded periodic-updates task** (`0ae3c7c`, `d765d05`) — `DashboardServer` now owns a `CancellationToken`; `axum::serve(...).with_graceful_shutdown` is wired in; `start_periodic_updates` returns a `JoinHandle` and exits on cancel. Public `shutdown()` / `shutdown_token()` / `run_until_cancelled()` API. The previous version's detached `tokio::spawn` ran forever and held an `Arc<DashboardService>` keeping storage alive across drops. Follow-up: `periodic_handle.await` is now bounded with a 5s `tokio::time::timeout` then `abort()`, so a hung `get_server_statistics()` against an unhealthy backend can't block the caller's shutdown sequence.

## Quality fixes

- **fix(server): jitter the worker error back-off and pin MissedTickBehavior** (`4e10e6a`) — Worker fleets observing the same transient backend failure used to resume in lock-step on a hardcoded 5s sleep. Adds 0–1500ms jitter. Also pins `MissedTickBehavior::Skip` so a slow worker doesn't burst-tick.

- **refactor(storage): MonitoringApi::list filters by JobStateKind, not JobState** (`0236287`) — Callers used to construct dummy `JobState::enqueued("default")` etc. just to pick a variant for filtering — the inner fields were silently ignored. Now takes the `JobStateKind` discriminant directly.

- **fix(tests, redis): clear pre-existing test failures** (`604b08c`) — Five flaky/wrong tests + one off-by-one in `RedisStorage::get_available_jobs` that backed one of them. Postgres config tests asserted the hardcoded fallback URL but `Default::default()` reads `DATABASE_URL`; postgres lock test used a non-UUID job_id; race tests collided on shared keys. The Redis bug: `(-1_isize as usize) as isize` round-tripped to -1 then subtracted 1, so `ZREVRANGE 0, -2` excluded the last element — limit-less `get_available_jobs` always lost one entry off the end.

- **docs(storage): contract / cap / timestamp clarifications** (`d765d05`, `a5fbe08`) — Public-trait docs now spell out: (a) callers must NOT call `update()` on jobs returned by `claim_due_*` (the storage already persisted the transition); (b) Redis `fetch_and_lock_job` scans up to 1024 candidates when a queue filter is set, so queue-scoped workers can transiently see `Ok(None)` if more than 1024 ineligible-queue jobs queue ahead of an eligible one (per-queue ZSETs are the future fix; Postgres / Memory aren't capped); (c) RFC3339 microsecond precision is consistent across chrono serde, Lua-formatted `now_iso`, and Postgres `to_jsonb(NOW())` so lex comparison of time fields stays chronological across backends. Plus a defensive zero-limit guard on the Lua claim path and a stale-comment refresh in `reclaim_jobs_from_server`.

## Breaking changes (callout for downstream)

- **`MonitoringApi::list` signature**: `Option<&JobState>` → `Option<JobStateKind>`. Callers passing dummy `JobState` values to pick a variant must switch to the discriminant directly.
- **`MonitoringApi::update_if_state` (new required method)**: anyone with a custom `MonitoringApi` impl outside this crate must add it. The three in-tree backends (`MemoryStorage`, `RedisStorage`, `PostgresStorage`) plus `StorageInstance` are all updated.
- **`StorageError` shorthand variants** (`ConnectionError`, `SerializationError`, `DeserializationError`, `OperationError`) gained a `source: Option<Box<dyn Error + Send + Sync>>` field. Pattern matches like `StorageError::DeserializationError { message }` now need `{ message, source, .. }` (or `..` alone) to be exhaustive.

## New tests

- `tests/queue_filter_test.rs` — cross-backend queue filter contract (4 tests).
- `tests/claim_due_jobs_test.rs` — atomic claim-and-transition contract (memory + redis + postgres × {scheduled, retry}).
- `tests/processing_recovery_test.rs` — postgres round-trip for `requeue_stranded_jobs` / `reclaim_jobs_from_server` after the JSON-path fix.
- `tests/update_if_state_test.rs` — CAS contract across all three backends, including the stomp-avoidance scenario.
- `tests/dashboard_shutdown_test.rs` — `DashboardServer::start` returns promptly when `shutdown()` fires; external-cancellation propagation; and a `HangingMonitoringApi`-backed test that proves the 5s `periodic_handle` timeout actually unwinds a wedged storage call.

## Test plan

- [x] `cargo build --all-features --all-targets` clean.
- [x] `cargo fmt` applied.
- [x] `cargo test --all-targets --no-fail-fast` (default features) — every test binary green.
- [x] Full suite single-threaded with Redis + Postgres up, `--all-features`: 168/168 tests pass.
- [x] Same suite without `REDIS_URL`/`DATABASE_URL` set: same totals pass.
- [x] Reviewer to spot-check the Lua scripts (`fetch_and_lock_job`, `claim_due_jobs_lua`, `update_if_state`, `update`) for atomicity edge cases.
- [x] Reviewer to confirm the public-API additions (`update_if_state`, `claim_due_*`, signature changes above) are acceptable for the next release.

## What's deliberately out of scope (follow-up)

- **I1+I2 from the review** — splitting `Storage` into 5 cohesive sub-traits (`JobStore + JobLocker + RecurringStore + ServerRegistry + NamedLocks`) and retiring the `StorageInstance` enum (350+ lines of dispatch boilerplate) for `Arc<dyn Storage>`. Real architectural change worth its own PR.
- **Redis per-queue ZSETs** — would eliminate the documented 1024-cap on `fetch_and_lock_job` queue filtering. Real correctness improvement, planned alongside the I1+I2 refactor on `chore/code-review-batch-2`.
- **Postgres `update_if_state` single-statement CTE** — would save one round-trip on the mismatch path. Dashboard retry is human-triggered and slow already; the latency saving doesn't justify complexity here.
- **`StorageError` variant consolidation** — the enum now carries both the canonical shape (`Connection`, `Serialization`, `OperationFailed`) and the source-bearing shorthand shape (`ConnectionError`, `SerializationError`, `DeserializationError`, `OperationError`). Both are reachable, both have `source` plumbed through, and the `From<StorageError> for QmlError` impl unifies them. Resolving the duplication (either deprecate-and-remove the older shape, or fold the shorthand into the canonical with `#[from]`) is a focused error-enum refactor better done as its own PR — touching it here would balloon this batch and re-pattern-match every call site.
