### PR TITLE
Code review batch 2: postgres indexes, named-lock sweeper, error consolidation, per-queue Redis ZSETs

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -70,11 +70,72 @@ CREATE INDEX IF NOT EXISTS idx_qml_jobs_expires_at ON qml.qml_jobs(expires_at) W
 CREATE INDEX IF NOT EXISTS idx_qml_jobs_locked_by ON qml.qml_jobs(locked_by) WHERE locked_by IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_qml_jobs_lock_expires ON qml.qml_jobs(lock_expires_at) WHERE lock_expires_at IS NOT NULL;
 
--- Job type and timeout indexes
+-- Job type index
 CREATE INDEX IF NOT EXISTS idx_qml_jobs_job_type ON qml.qml_jobs(job_type) WHERE job_type IS NOT NULL;
 
--- Add indexes for the new columns
-CREATE INDEX IF NOT EXISTS idx_qml_jobs_job_type ON qml.qml_jobs(job_type) WHERE job_type IS NOT NULL;
+-- Helper: parse an ISO-8601 timestamp text out of state_data and return
+-- it as a timestamptz. Marked IMMUTABLE so it's usable in expression
+-- indexes (Postgres rejects `text::timestamptz` in indexes — that cast
+-- is STABLE because it can depend on session DateStyle / TimeZone).
+--
+-- This is safe to mark IMMUTABLE because every writer in the codebase
+-- emits timestamps with an explicit UTC suffix:
+--   * chrono's serde adapter writes RFC3339 with `Z`.
+--   * Lua scripts use `to_rfc3339_opts(SecondsFormat::Micros, true)`.
+--   * `to_jsonb(NOW())` writes `+00:00`.
+-- All three formats parse to the same UTC instant regardless of
+-- session timezone, so the index value is stable across sessions.
+CREATE OR REPLACE FUNCTION qml.parse_iso_utc(t text)
+    RETURNS timestamptz
+    LANGUAGE sql
+    IMMUTABLE PARALLEL SAFE STRICT
+AS $func$
+    SELECT ($1::timestamp AT TIME ZONE 'UTC')
+$func$;
+
+COMMENT ON FUNCTION qml.parse_iso_utc(text) IS
+    'IMMUTABLE wrapper for parsing UTC ISO-8601 timestamps out of state_data; required because text::timestamptz is STABLE and can''t be used directly in expression indexes';
+
+-- Hot-path index for `fetch_and_lock_job` / `claim_due_*`. The query is:
+--
+--   SELECT id FROM qml_jobs
+--   WHERE state_name IN ('enqueued', 'awaiting_retry')
+--     [AND queue_name = ANY(...)]
+--   ORDER BY priority DESC, created_at ASC
+--   FOR UPDATE SKIP LOCKED LIMIT 1
+--
+-- The pre-existing `idx_qml_jobs_state_priority` covers the IN-list but
+-- forces a sort on `created_at` per priority bucket and doesn't include
+-- `queue_name`. This partial index covers the access path exactly:
+-- only enqueued/awaiting_retry rows, indexed by (queue, priority desc,
+-- created_at asc) so workers polling a specific queue walk the index
+-- in claim order.
+CREATE INDEX IF NOT EXISTS idx_qml_jobs_fetch
+    ON qml.qml_jobs (queue_name, priority DESC, created_at ASC)
+    WHERE state_name IN ('enqueued', 'awaiting_retry');
+
+-- Time-predicate index for `fetch_due_scheduled_jobs` and
+-- `claim_due_scheduled_jobs`. The query predicate is rewritten to use
+-- `qml.parse_iso_utc(...)` so the planner can match this index.
+-- Without the index, the planner falls back to a sequential scan +
+-- per-row JSON extraction.
+CREATE INDEX IF NOT EXISTS idx_qml_jobs_due_scheduled
+    ON qml.qml_jobs (
+        qml.parse_iso_utc(state_data->'Scheduled'->>'enqueue_at'),
+        priority DESC,
+        created_at ASC
+    )
+    WHERE state_name = 'scheduled';
+
+-- Time-predicate index for `fetch_due_retry_jobs` and
+-- `claim_due_retry_jobs`. Mirrors the scheduled one.
+CREATE INDEX IF NOT EXISTS idx_qml_jobs_due_retry
+    ON qml.qml_jobs (
+        qml.parse_iso_utc(state_data->'AwaitingRetry'->>'retry_at'),
+        priority DESC,
+        created_at ASC
+    )
+    WHERE state_name = 'awaiting_retry';
 
 -- =========================================================================
 -- RECURRING JOB TEMPLATES (R1)

--- a/src/processing/cleanup.rs
+++ b/src/processing/cleanup.rs
@@ -66,17 +66,37 @@ impl CleanupWorker {
     }
 
     /// One cleanup sweep. Exposed for tests.
+    ///
+    /// Two pieces of work, in order:
+    /// 1. Delete jobs whose `expires_at` has passed (final-state sweep).
+    /// 2. Delete generic named locks whose `expires_at` has passed.
+    ///
+    /// Both share a single `now` so a tick is consistent. Returns the
+    /// number of expired *jobs* removed (preserved for backward
+    /// compatibility with the existing test); named-lock removal is
+    /// logged but doesn't change the return.
     pub async fn sweep_once(&self) -> Result<usize> {
-        let removed = self
-            .storage
-            .delete_expired_jobs(Utc::now())
-            .await
-            .map_err(|e| QmlError::StorageError {
-                message: format!("Failed to delete expired jobs: {}", e),
-            })?;
+        let now = Utc::now();
+        let removed =
+            self.storage
+                .delete_expired_jobs(now)
+                .await
+                .map_err(|e| QmlError::StorageError {
+                    message: format!("Failed to delete expired jobs: {}", e),
+                })?;
         if removed > 0 {
             info!("Cleanup worker removed {} expired jobs", removed);
         }
+
+        match self.storage.cleanup_expired_named_locks(now).await {
+            Ok(0) => {}
+            Ok(n) => info!("Cleanup worker removed {} expired named locks", n),
+            // A failed lock sweep shouldn't poison the whole tick — we
+            // already swept jobs successfully and a future tick will
+            // retry the lock cleanup.
+            Err(e) => error!("Failed to clean up expired named locks: {}", e),
+        }
+
         Ok(removed)
     }
 }

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -1,7 +1,13 @@
 use crate::error::QmlError;
 use thiserror::Error;
 
-/// Storage-specific errors that can occur during job persistence operations
+/// Storage-specific errors that can occur during job persistence operations.
+///
+/// Every variant that wraps an underlying driver error carries a
+/// `source: Option<Box<dyn Error + Send + Sync>>` field with `#[source]`,
+/// so callers can walk `Error::source()` or downcast to the concrete
+/// type. Earlier revisions stringified the cause into `message` and
+/// dropped the chain; the helper constructors here always preserve it.
 #[derive(Error, Debug)]
 pub enum StorageError {
     /// Connection-related errors (network, authentication, etc.)
@@ -12,9 +18,20 @@ pub enum StorageError {
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
 
-    /// Serialization/deserialization errors when converting jobs to/from storage format
+    /// Encoding a value (job, state, metadata) into the storage's
+    /// transport format failed.
     #[error("Serialization error: {message}")]
     Serialization {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// Decoding a value out of the storage's transport format failed.
+    /// Distinct from [`Serialization`] so callers handling a corrupt-row
+    /// recovery path can match precisely.
+    #[error("Deserialization error: {message}")]
+    Deserialization {
         message: String,
         #[source]
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
@@ -36,10 +53,13 @@ pub enum StorageError {
     #[error("Storage configuration error: {message}")]
     Configuration { message: String },
 
-    /// General storage operation errors
-    #[error("Storage operation failed: {operation} - {message}")]
+    /// A storage-engine operation failed for a reason that isn't a
+    /// connection / serialization / not-found / capacity issue. The
+    /// `message` field should already include enough operation context
+    /// (e.g. `"Failed to fetch and lock job"`); the underlying driver
+    /// error is preserved on `source`.
+    #[error("Storage operation failed: {message}")]
     OperationFailed {
-        operation: String,
         message: String,
         #[source]
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
@@ -60,41 +80,6 @@ pub enum StorageError {
     /// Invalid job data format
     #[error("Invalid job data: {message}")]
     InvalidJobData { message: String },
-
-    /// Connection-specific error (shorthand). Carries an optional source so
-    /// the underlying driver error can be inspected via `Error::source()` or
-    /// downcast — earlier versions stringified the cause into `message` and
-    /// dropped the chain.
-    #[error("Connection error: {message}")]
-    ConnectionError {
-        message: String,
-        #[source]
-        source: Option<Box<dyn std::error::Error + Send + Sync>>,
-    },
-
-    /// Serialization-specific error (shorthand)
-    #[error("Serialization error: {message}")]
-    SerializationError {
-        message: String,
-        #[source]
-        source: Option<Box<dyn std::error::Error + Send + Sync>>,
-    },
-
-    /// Deserialization-specific error (shorthand)
-    #[error("Deserialization error: {message}")]
-    DeserializationError {
-        message: String,
-        #[source]
-        source: Option<Box<dyn std::error::Error + Send + Sync>>,
-    },
-
-    /// Operation-specific error (shorthand)
-    #[error("Operation error: {message}")]
-    OperationError {
-        message: String,
-        #[source]
-        source: Option<Box<dyn std::error::Error + Send + Sync>>,
-    },
 }
 
 impl StorageError {
@@ -136,6 +121,25 @@ impl StorageError {
         }
     }
 
+    /// Create a deserialization error with a message
+    pub fn deserialization<S: Into<String>>(message: S) -> Self {
+        Self::Deserialization {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Create a deserialization error with a message and source error
+    pub fn deserialization_with_source<S: Into<String>>(
+        message: S,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    ) -> Self {
+        Self::Deserialization {
+            message: message.into(),
+            source: Some(source),
+        }
+    }
+
     /// Create a job not found error
     pub fn job_not_found<S: Into<String>>(job_id: S) -> Self {
         Self::JobNotFound {
@@ -162,23 +166,21 @@ impl StorageError {
         }
     }
 
-    /// Create an operation failed error
-    pub fn operation_failed<S: Into<String>, T: Into<String>>(operation: S, message: T) -> Self {
+    /// Create an operation-failed error without a source (e.g. when the
+    /// failure is logical, not driven by an underlying driver error).
+    pub fn operation_failed<S: Into<String>>(message: S) -> Self {
         Self::OperationFailed {
-            operation: operation.into(),
             message: message.into(),
             source: None,
         }
     }
 
-    /// Create an operation failed error with source
-    pub fn operation_failed_with_source<S: Into<String>, T: Into<String>>(
-        operation: S,
-        message: T,
+    /// Create an operation-failed error with a captured source.
+    pub fn operation_failed_with_source<S: Into<String>>(
+        message: S,
         source: Box<dyn std::error::Error + Send + Sync>,
     ) -> Self {
         Self::OperationFailed {
-            operation: operation.into(),
             message: message.into(),
             source: Some(source),
         }
@@ -198,51 +200,51 @@ impl StorageError {
         }
     }
 
-    /// Connection-error shorthand with a captured source. Prefer this over
-    /// `ConnectionError { message, source: None }` so the cause chain is
-    /// preserved for downstream `Error::source()` callers.
+    /// `Connection` shorthand that takes the raw error as a typed
+    /// generic, boxes it, and attaches it as the source — saves the
+    /// caller a `Box::new(...)`.
     pub fn conn_err<M, E>(message: M, source: E) -> Self
     where
         M: Into<String>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        Self::ConnectionError {
+        Self::Connection {
             message: message.into(),
             source: Some(Box::new(source)),
         }
     }
 
-    /// Serialization-error shorthand with a captured source.
+    /// `Serialization` shorthand with a captured source.
     pub fn ser_err<M, E>(message: M, source: E) -> Self
     where
         M: Into<String>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        Self::SerializationError {
+        Self::Serialization {
             message: message.into(),
             source: Some(Box::new(source)),
         }
     }
 
-    /// Deserialization-error shorthand with a captured source.
+    /// `Deserialization` shorthand with a captured source.
     pub fn de_err<M, E>(message: M, source: E) -> Self
     where
         M: Into<String>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        Self::DeserializationError {
+        Self::Deserialization {
             message: message.into(),
             source: Some(Box::new(source)),
         }
     }
 
-    /// Operation-error shorthand with a captured source.
+    /// `OperationFailed` shorthand with a captured source.
     pub fn op_err<M, E>(message: M, source: E) -> Self
     where
         M: Into<String>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        Self::OperationError {
+        Self::OperationFailed {
             message: message.into(),
             source: Some(Box::new(source)),
         }
@@ -254,13 +256,12 @@ impl From<StorageError> for QmlError {
     fn from(err: StorageError) -> Self {
         match err {
             StorageError::JobNotFound { job_id } => QmlError::JobNotFound { job_id },
-            // Both Serialization shapes map onto QmlError::SerializationError.
-            // The shorthand variants previously fell through to the generic
-            // StorageError arm, which dropped the typed signal callers were
-            // relying on.
+            // Both Serialization and Deserialization map onto
+            // QmlError::SerializationError. QmlError doesn't currently
+            // separate the two; if it grows a Deserialization variant,
+            // this is the place to split them.
             StorageError::Serialization { message, .. }
-            | StorageError::SerializationError { message, .. }
-            | StorageError::DeserializationError { message, .. } => {
+            | StorageError::Deserialization { message, .. } => {
                 QmlError::SerializationError { message }
             }
             _ => QmlError::StorageError {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -652,6 +652,13 @@ impl Storage for MemoryStorage {
             _ => Ok(false),
         }
     }
+
+    async fn cleanup_expired_named_locks(&self, now: DateTime<Utc>) -> Result<usize, StorageError> {
+        let mut locks = self.named_locks.write().unwrap();
+        let before = locks.len();
+        locks.retain(|_, lock| lock.expires_at > now);
+        Ok(before - locks.len())
+    }
 }
 
 impl MemoryStorage {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -619,7 +619,7 @@ impl Storage for MemoryStorage {
         let now = Utc::now();
         let new_expires_at = now
             + chrono::Duration::from_std(ttl).map_err(|e| {
-                StorageError::operation_failed("try_acquire_lock", format!("invalid ttl: {}", e))
+                StorageError::operation_failed(format!("try_acquire_lock: invalid ttl: {}", e))
             })?;
 
         let mut locks = self.named_locks.write().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -666,6 +666,21 @@ pub trait Storage: MonitoringApi + Send + Sync {
     /// Returns `Ok(true)` if a matching row was deleted, `Ok(false)` if
     /// no row existed or it was owned by someone else.
     async fn release_lock(&self, resource: &str, owner: &str) -> Result<bool, StorageError>;
+
+    /// Background sweep of expired generic named locks.
+    ///
+    /// Returns the number of expired entries removed. Backends differ:
+    /// - **Postgres**: `DELETE FROM qml_locks WHERE expires_at < $1`.
+    ///   The `try_acquire_lock` path replaces expired rows opportunistically
+    ///   on contention, but a workload that takes a lock once and never
+    ///   re-acquires (e.g. one-shot named locks) accumulates rows
+    ///   indefinitely without this sweep.
+    /// - **Redis**: a no-op — named locks use the native Redis `PX` TTL
+    ///   so the server expires them automatically. Returns `Ok(0)`.
+    /// - **Memory**: drops entries from the in-process `named_locks` map.
+    ///
+    /// Called by [`crate::processing::CleanupWorker`] on each tick.
+    async fn cleanup_expired_named_locks(&self, now: DateTime<Utc>) -> Result<usize, StorageError>;
 }
 
 /// Storage instance that can hold any storage implementation
@@ -1255,6 +1270,16 @@ impl Storage for StorageInstance {
             StorageInstance::Redis(storage) => storage.release_lock(resource, owner).await,
             #[cfg(feature = "postgres")]
             StorageInstance::Postgres(storage) => storage.release_lock(resource, owner).await,
+        }
+    }
+
+    async fn cleanup_expired_named_locks(&self, now: DateTime<Utc>) -> Result<usize, StorageError> {
+        match self {
+            StorageInstance::Memory(storage) => storage.cleanup_expired_named_locks(now).await,
+            #[cfg(feature = "redis")]
+            StorageInstance::Redis(storage) => storage.cleanup_expired_named_locks(now).await,
+            #[cfg(feature = "postgres")]
+            StorageInstance::Postgres(storage) => storage.cleanup_expired_named_locks(now).await,
         }
     }
 }

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1697,6 +1697,29 @@ impl Storage for PostgresStorage {
             })?;
         Ok(result.rows_affected() > 0)
     }
+
+    async fn cleanup_expired_named_locks(&self, now: DateTime<Utc>) -> Result<usize, StorageError> {
+        // The takeover-on-acquire path in `try_acquire_lock` only fires
+        // when a peer attempts to claim a specific resource that's
+        // already expired. One-shot lock workloads (a recurring report
+        // that takes a lock once, finishes, and never re-acquires) leak
+        // rows indefinitely without this sweep. The partial index
+        // `idx_qml_locks_expires_at` keeps the DELETE cheap.
+        let locks_table = self.locks_table_name();
+        let query = format!(
+            "DELETE FROM {table} WHERE expires_at < $1",
+            table = locks_table
+        );
+        let result = sqlx::query(&query)
+            .bind(now)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::OperationError {
+                message: format!("Failed to clean up expired named locks: {}", e),
+                source: Some(Box::new(e)),
+            })?;
+        Ok(result.rows_affected() as usize)
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -52,7 +52,7 @@ impl PostgresStorage {
             .max_lifetime(config.max_lifetime)
             .connect(&config.database_url)
             .await
-            .map_err(|e| StorageError::ConnectionError {
+            .map_err(|e| StorageError::Connection {
                 message: format!("Failed to connect to PostgreSQL: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -119,7 +119,6 @@ impl PostgresStorage {
             .fetch_one(&self.pool)
             .await
             .map_err(|e| StorageError::OperationFailed {
-                operation: "schema_check".to_string(),
                 message: format!("Failed to check schema existence: {}", e),
                 source: Some(Box::new(e)),
             })
@@ -135,7 +134,6 @@ impl PostgresStorage {
             .fetch_one(&self.pool)
             .await
             .map_err(|e| StorageError::OperationFailed {
-                operation: "table_check".to_string(),
                 message: format!(
                     "Failed to check table existence for '{}': {}",
                     table_name, e
@@ -191,27 +189,24 @@ impl PostgresStorage {
                     operation()
                         .await
                         .map_err(|retry_err| StorageError::OperationFailed {
-                            operation: operation_name.to_string(),
                             message: format!(
-                                "Operation failed even after migration: {}",
-                                retry_err
+                                "{}: operation failed even after migration: {}",
+                                operation_name, retry_err
                             ),
                             source: Some(Box::new(retry_err)),
                         })
                 } else {
                     Err(StorageError::OperationFailed {
-                        operation: operation_name.to_string(),
                         message: format!(
-                            "Schema error detected but auto_migrate is disabled. Please run migrations manually: {}",
-                            e
+                            "{}: schema error detected but auto_migrate is disabled — run migrations manually: {}",
+                            operation_name, e
                         ),
                         source: Some(Box::new(e)),
                     })
                 }
             }
             Err(e) => Err(StorageError::OperationFailed {
-                operation: operation_name.to_string(),
-                message: format!("Database operation failed: {}", e),
+                message: format!("{}: database operation failed: {}", operation_name, e),
                 source: Some(Box::new(e)),
             }),
         }
@@ -264,13 +259,14 @@ impl PostgresStorage {
         );
 
         let bound = bind(sqlx::query(&query));
-        let result = bound
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StorageError::OperationError {
-                message: format!("{}: {}", op_message, e),
-                source: Some(Box::new(e)),
-            })?;
+        let result =
+            bound
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StorageError::OperationFailed {
+                    message: format!("{}: {}", op_message, e),
+                    source: Some(Box::new(e)),
+                })?;
 
         Ok(result.rows_affected() as usize)
     }
@@ -400,83 +396,83 @@ impl PostgresStorage {
     fn row_to_job(row: &sqlx::postgres::PgRow) -> Result<Job, StorageError> {
         let id: Uuid = row
             .try_get("id")
-            .map_err(|e| StorageError::DeserializationError {
+            .map_err(|e| StorageError::Deserialization {
                 message: format!("Failed to get job ID: {}", e),
                 source: Some(Box::new(e)),
             })?;
 
         let method_name: String =
             row.try_get("method_name")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get method name: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let payload: serde_json::Value =
             row.try_get("arguments")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get payload: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let created_at: DateTime<Utc> =
             row.try_get("created_at")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get created_at: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let state_name: String =
             row.try_get("state_name")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get state name: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let state_data: serde_json::Value =
             row.try_get("state_data")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get state data: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let queue_name: String =
             row.try_get("queue_name")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get queue name: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
-        let priority: i32 =
-            row.try_get("priority")
-                .map_err(|e| StorageError::DeserializationError {
-                    message: format!("Failed to get priority: {}", e),
-                    source: Some(Box::new(e)),
-                })?;
+        let priority: i32 = row
+            .try_get("priority")
+            .map_err(|e| StorageError::Deserialization {
+                message: format!("Failed to get priority: {}", e),
+                source: Some(Box::new(e)),
+            })?;
 
         let max_retries: i32 =
             row.try_get("max_retries")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get max_retries: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let current_retries: i32 =
             row.try_get("current_retries")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get current_retries: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let metadata_json: Option<serde_json::Value> =
             row.try_get("metadata")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get metadata: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let metadata: HashMap<String, String> = if let Some(meta) = metadata_json {
-            serde_json::from_value(meta).map_err(|e| StorageError::DeserializationError {
+            serde_json::from_value(meta).map_err(|e| StorageError::Deserialization {
                 message: format!("Failed to deserialize metadata: {}", e),
                 source: Some(Box::new(e)),
             })?
@@ -486,21 +482,21 @@ impl PostgresStorage {
 
         let job_type: Option<String> =
             row.try_get("job_type")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get job_type: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let timeout_seconds: Option<i32> =
             row.try_get("timeout_seconds")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get timeout_seconds: {}", e),
                     source: Some(Box::new(e)),
                 })?;
 
         let expires_at: Option<DateTime<Utc>> =
             row.try_get("expires_at")
-                .map_err(|e| StorageError::DeserializationError {
+                .map_err(|e| StorageError::Deserialization {
                     message: format!("Failed to get expires_at: {}", e),
                     source: Some(Box::new(e)),
                 })?;
@@ -545,7 +541,7 @@ impl PostgresStorage {
 
     /// Convert JobState to JSON data
     fn job_state_to_data(state: &JobState) -> Result<serde_json::Value, StorageError> {
-        serde_json::to_value(state).map_err(|e| StorageError::SerializationError {
+        serde_json::to_value(state).map_err(|e| StorageError::Serialization {
             message: format!("Failed to serialize job state: {}", e),
             source: Some(Box::new(e)),
         })
@@ -556,7 +552,7 @@ impl PostgresStorage {
         state_name: &str,
         state_data: &serde_json::Value,
     ) -> Result<JobState, StorageError> {
-        serde_json::from_value(state_data.clone()).map_err(|e| StorageError::DeserializationError {
+        serde_json::from_value(state_data.clone()).map_err(|e| StorageError::Deserialization {
             message: format!("Failed to deserialize job state {}: {}", state_name, e),
             source: Some(Box::new(e)),
         })
@@ -598,7 +594,7 @@ impl PostgresStorage {
 
     /// Materialize a row from `qml_servers` into a [`ServerInfo`].
     fn row_to_server_info(row: &sqlx::postgres::PgRow) -> Result<ServerInfo, StorageError> {
-        let err = |field: &str, e: sqlx::Error| StorageError::DeserializationError {
+        let err = |field: &str, e: sqlx::Error| StorageError::Deserialization {
             message: format!("Failed to get {}: {}", field, e),
             source: Some(Box::new(e)),
         };
@@ -623,7 +619,7 @@ impl PostgresStorage {
 
     /// Materialize a row from `qml_recurring_jobs` into a [`RecurringJob`].
     fn row_to_recurring(row: &sqlx::postgres::PgRow) -> Result<RecurringJob, StorageError> {
-        let err = |field: &str, e: sqlx::Error| StorageError::DeserializationError {
+        let err = |field: &str, e: sqlx::Error| StorageError::Deserialization {
             message: format!("Failed to get {}: {}", field, e),
             source: Some(Box::new(e)),
         };
@@ -691,12 +687,12 @@ impl MonitoringApi for PostgresStorage {
         let metadata = if job.metadata.is_empty() {
             None
         } else {
-            Some(serde_json::to_value(&job.metadata).map_err(|e| {
-                StorageError::SerializationError {
+            Some(
+                serde_json::to_value(&job.metadata).map_err(|e| StorageError::Serialization {
                     message: format!("Failed to serialize metadata: {}", e),
                     source: Some(Box::new(e)),
-                }
-            })?)
+                })?,
+            )
         };
 
         let job_id = Uuid::from_str(&job.id).map_err(|e| StorageError::InvalidJobData {
@@ -731,7 +727,7 @@ impl MonitoringApi for PostgresStorage {
             .bind(job.expires_at)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to update job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -758,12 +754,12 @@ impl MonitoringApi for PostgresStorage {
         let metadata = if job.metadata.is_empty() {
             None
         } else {
-            Some(serde_json::to_value(&job.metadata).map_err(|e| {
-                StorageError::SerializationError {
+            Some(
+                serde_json::to_value(&job.metadata).map_err(|e| StorageError::Serialization {
                     message: format!("Failed to serialize metadata: {}", e),
                     source: Some(Box::new(e)),
-                }
-            })?)
+                })?,
+            )
         };
 
         let expected_state_name = match expected {
@@ -810,7 +806,7 @@ impl MonitoringApi for PostgresStorage {
             .bind(job.expires_at)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to update_if_state job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -825,7 +821,7 @@ impl MonitoringApi for PostgresStorage {
             .bind(job_id)
             .fetch_optional(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to verify job existence: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -847,7 +843,7 @@ impl MonitoringApi for PostgresStorage {
             .bind(job_uuid)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to delete job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -907,7 +903,7 @@ impl MonitoringApi for PostgresStorage {
             sqlx_query
                 .fetch_all(&self.pool)
                 .await
-                .map_err(|e| StorageError::OperationError {
+                .map_err(|e| StorageError::OperationFailed {
                     message: format!("Failed to list jobs: {}", e),
                     source: Some(Box::new(e)),
                 })?;
@@ -929,7 +925,7 @@ impl MonitoringApi for PostgresStorage {
         let rows = sqlx::query(&query)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to get job counts: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -939,17 +935,17 @@ impl MonitoringApi for PostgresStorage {
         for row in rows {
             let state_name: String =
                 row.try_get("state_name")
-                    .map_err(|e| StorageError::DeserializationError {
+                    .map_err(|e| StorageError::Deserialization {
                         message: format!("Failed to get state name from count query: {}", e),
                         source: Some(Box::new(e)),
                     })?;
 
-            let count: i64 =
-                row.try_get("count")
-                    .map_err(|e| StorageError::DeserializationError {
-                        message: format!("Failed to get count from count query: {}", e),
-                        source: Some(Box::new(e)),
-                    })?;
+            let count: i64 = row
+                .try_get("count")
+                .map_err(|e| StorageError::Deserialization {
+                    message: format!("Failed to get count from count query: {}", e),
+                    source: Some(Box::new(e)),
+                })?;
 
             let kind = match state_name.as_str() {
                 "enqueued" => JobStateKind::Enqueued,
@@ -976,12 +972,12 @@ impl Storage for PostgresStorage {
         let metadata = if job.metadata.is_empty() {
             None
         } else {
-            Some(serde_json::to_value(&job.metadata).map_err(|e| {
-                StorageError::SerializationError {
+            Some(
+                serde_json::to_value(&job.metadata).map_err(|e| StorageError::Serialization {
                     message: format!("Failed to serialize metadata: {}", e),
                     source: Some(Box::new(e)),
-                }
-            })?)
+                })?,
+            )
         };
 
         let job_id = Uuid::from_str(&job.id).map_err(|e| StorageError::InvalidJobData {
@@ -1051,7 +1047,7 @@ impl Storage for PostgresStorage {
         let rows = sqlx::query(&query)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to get available jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1090,7 +1086,7 @@ impl Storage for PostgresStorage {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to fetch due scheduled jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1125,7 +1121,7 @@ impl Storage for PostgresStorage {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to fetch due retry jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1180,7 +1176,7 @@ impl Storage for PostgresStorage {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to claim due scheduled jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1230,7 +1226,7 @@ impl Storage for PostgresStorage {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to claim due retry jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1318,7 +1314,7 @@ impl Storage for PostgresStorage {
         }
 
         let row = sqlx_query.fetch_optional(&self.pool).await.map_err(|e| {
-            StorageError::OperationError {
+            StorageError::OperationFailed {
                 message: format!("Failed to fetch and lock job: {}", e),
                 source: Some(Box::new(e)),
             }
@@ -1349,7 +1345,7 @@ impl Storage for PostgresStorage {
             .bind(timeout_seconds as i32)
             .fetch_one(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to acquire job lock: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1370,7 +1366,7 @@ impl Storage for PostgresStorage {
             .bind(worker_id)
             .fetch_one(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to release job lock: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1430,7 +1426,7 @@ impl Storage for PostgresStorage {
             .bind(job.enabled)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to upsert recurring job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1443,7 +1439,7 @@ impl Storage for PostgresStorage {
             .bind(id)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to delete recurring job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1463,7 +1459,7 @@ impl Storage for PostgresStorage {
         let rows = sqlx::query(&query)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to list recurring jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1500,7 +1496,7 @@ impl Storage for PostgresStorage {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to fetch due recurring jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1528,7 +1524,7 @@ impl Storage for PostgresStorage {
             .bind(now)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to delete expired jobs: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1559,7 +1555,7 @@ impl Storage for PostgresStorage {
             .bind(&info.queues)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to register server: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1580,7 +1576,7 @@ impl Storage for PostgresStorage {
             .bind(now)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to heartbeat server: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1596,7 +1592,7 @@ impl Storage for PostgresStorage {
             .bind(server_id)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to deregister server: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1619,7 +1615,7 @@ impl Storage for PostgresStorage {
             .bind(stale_before)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to list dead servers: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1673,7 +1669,7 @@ impl Storage for PostgresStorage {
             .bind(ttl_secs)
             .fetch_optional(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to acquire lock: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1691,7 +1687,7 @@ impl Storage for PostgresStorage {
             .bind(owner)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to release lock: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1714,7 +1710,7 @@ impl Storage for PostgresStorage {
             .bind(now)
             .execute(&self.pool)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to clean up expired named locks: {}", e),
                 source: Some(Box::new(e)),
             })?;

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1036,8 +1036,8 @@ impl Storage for PostgresStorage {
             WHERE state_name IN ('enqueued', 'scheduled', 'awaiting_retry')
             AND (
                 state_name = 'enqueued' OR
-                (state_name = 'scheduled' AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= NOW()) OR
-                (state_name = 'awaiting_retry' AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= NOW())
+                (state_name = 'scheduled' AND qml.parse_iso_utc(state_data->'Scheduled'->>'enqueue_at') <= NOW()) OR
+                (state_name = 'awaiting_retry' AND qml.parse_iso_utc(state_data->'AwaitingRetry'->>'retry_at') <= NOW())
             )
             ORDER BY priority DESC, created_at ASC
             "#,
@@ -1078,7 +1078,7 @@ impl Storage for PostgresStorage {
                    queue_name, priority, max_retries, current_retries, metadata, job_type, timeout_seconds, expires_at
             FROM {}
             WHERE state_name = 'scheduled'
-              AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= $1
+              AND qml.parse_iso_utc(state_data->'Scheduled'->>'enqueue_at') <= $1
             ORDER BY priority DESC, created_at ASC
             LIMIT $2
             "#,
@@ -1113,7 +1113,7 @@ impl Storage for PostgresStorage {
                    queue_name, priority, max_retries, current_retries, metadata, job_type, timeout_seconds, expires_at
             FROM {}
             WHERE state_name = 'awaiting_retry'
-              AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= $1
+              AND qml.parse_iso_utc(state_data->'AwaitingRetry'->>'retry_at') <= $1
             ORDER BY priority DESC, created_at ASC
             LIMIT $2
             "#,
@@ -1152,7 +1152,7 @@ impl Storage for PostgresStorage {
             WITH due AS (
                 SELECT id FROM {table}
                 WHERE state_name = 'scheduled'
-                  AND (state_data->'Scheduled'->>'enqueue_at')::timestamptz <= $1
+                  AND qml.parse_iso_utc(state_data->'Scheduled'->>'enqueue_at') <= $1
                 ORDER BY priority DESC, created_at ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2
@@ -1202,7 +1202,7 @@ impl Storage for PostgresStorage {
             WITH due AS (
                 SELECT id FROM {table}
                 WHERE state_name = 'awaiting_retry'
-                  AND (state_data->'AwaitingRetry'->>'retry_at')::timestamptz <= $1
+                  AND qml.parse_iso_utc(state_data->'AwaitingRetry'->>'retry_at') <= $1
                 ORDER BY priority DESC, created_at ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -1487,6 +1487,18 @@ impl Storage for RedisStorage {
             .await?;
         Ok(deleted == 1)
     }
+
+    async fn cleanup_expired_named_locks(
+        &self,
+        _now: DateTime<Utc>,
+    ) -> Result<usize, StorageError> {
+        // Redis named locks use the server's native `PX` TTL on each key
+        // (set by `try_acquire_lock`), so the Redis server itself drops
+        // expired entries — there's no equivalent of the Postgres
+        // accumulating-row problem. Returning Ok(0) keeps the
+        // CleanupWorker tick cheap on Redis-backed deployments.
+        Ok(0)
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -60,8 +60,7 @@ impl RedisStorage {
             .map_err(|_| StorageError::timeout(self.config.command_timeout.as_millis() as u64))?
             .map_err(|e| {
                 StorageError::operation_failed_with_source(
-                    "Redis command",
-                    e.to_string(),
+                    format!("Redis command failed: {}", e),
                     Box::new(e),
                 )
             })
@@ -363,7 +362,7 @@ impl RedisStorage {
             .arg(limit as i64)
             .invoke_async(&mut conn)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to claim due {} jobs: {}", from_state_str, e),
                 source: Some(Box::new(e)),
             })?;
@@ -516,7 +515,7 @@ impl MonitoringApi for RedisStorage {
             .arg(new_available)
             .invoke_async(&mut conn)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to update job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -524,7 +523,7 @@ impl MonitoringApi for RedisStorage {
         match result.as_str() {
             "ok" => Ok(()),
             "missing" => Err(StorageError::job_not_found(job.id.clone())),
-            other => Err(StorageError::OperationError {
+            other => Err(StorageError::OperationFailed {
                 message: format!("Unexpected update response: {}", other),
                 source: None,
             }),
@@ -639,7 +638,7 @@ impl MonitoringApi for RedisStorage {
             .arg(new_available)
             .invoke_async(&mut conn)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to update_if_state job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -648,7 +647,7 @@ impl MonitoringApi for RedisStorage {
             "ok" => Ok(true),
             "mismatch" => Ok(false),
             "missing" => Err(StorageError::job_not_found(job.id.clone())),
-            other => Err(StorageError::OperationError {
+            other => Err(StorageError::OperationFailed {
                 message: format!("Unexpected update_if_state response: {}", other),
                 source: None,
             }),
@@ -1070,7 +1069,7 @@ impl Storage for RedisStorage {
             .arg(cap)
             .invoke_async(&mut conn)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to fetch and lock job: {}", e),
                 source: Some(Box::new(e)),
             })?;
@@ -1135,7 +1134,7 @@ impl Storage for RedisStorage {
             .arg(worker_id)
             .invoke_async(&mut conn)
             .await
-            .map_err(|e| StorageError::OperationError {
+            .map_err(|e| StorageError::OperationFailed {
                 message: format!("Failed to release job lock: {}", e),
                 source: Some(Box::new(e)),
             })?;

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -76,9 +76,21 @@ impl RedisStorage {
         format!("{}:state:{}", self.config.key_prefix, state)
     }
 
-    /// Get the Redis key for available jobs queue
+    /// Get the Redis key for available jobs queue (global, all queues
+    /// combined). Used by `get_available_jobs` and the no-filter path
+    /// of `fetch_and_lock_job`.
     fn available_jobs_key(&self) -> String {
         format!("{}:available", self.config.key_prefix)
+    }
+
+    /// Per-queue available-jobs ZSET. Maintained alongside the global
+    /// `qml:available` so queue-scoped fetches don't have to scan past
+    /// ineligible-queue jobs (the previous bounded-candidate-cap
+    /// behavior of `fetch_and_lock_job`'s Lua script) — they read
+    /// directly from `qml:available:<queue>` and pick the highest-score
+    /// member exactly.
+    fn available_jobs_by_queue_key(&self, queue: &str) -> String {
+        format!("{}:available:{}", self.config.key_prefix, queue)
     }
 
     /// Get the Redis key for job counts
@@ -182,14 +194,24 @@ impl RedisStorage {
         self.with_timeout::<_, ()>(conn.hincr(&counts_key, &state_str, 1))
             .await?;
 
-        // Update available jobs index
+        // Update both the global available ZSET and the per-queue one.
+        // The global is what `get_available_jobs` reads; the per-queue
+        // is what `fetch_and_lock_job` reads when a queue filter is
+        // set. The job's `queue` field is stable for its lifetime so a
+        // single per-queue key is enough — no need to also remove from
+        // a "previous queue" entry.
+        let by_queue_key = self.available_jobs_by_queue_key(&job.queue);
         if Self::is_job_available(job) {
             let score =
                 job.priority as f64 + (job.created_at.timestamp_millis() as f64 / 1_000_000.0);
             self.with_timeout::<_, ()>(conn.zadd(&available_key, &job.id, score))
                 .await?;
+            self.with_timeout::<_, ()>(conn.zadd(&by_queue_key, &job.id, score))
+                .await?;
         } else {
             self.with_timeout::<_, ()>(conn.zrem(&available_key, &job.id))
+                .await?;
+            self.with_timeout::<_, ()>(conn.zrem(&by_queue_key, &job.id))
                 .await?;
         }
 
@@ -215,6 +237,7 @@ impl RedisStorage {
         let state_key = self.state_index_key(&state_str);
         let all_jobs_key = self.all_jobs_key();
         let available_key = self.available_jobs_key();
+        let by_queue_key = self.available_jobs_by_queue_key(&job.queue);
         let counts_key = self.job_counts_key();
 
         self.with_timeout::<_, ()>(conn.srem(&state_key, job_id))
@@ -222,6 +245,8 @@ impl RedisStorage {
         self.with_timeout::<_, ()>(conn.srem(&all_jobs_key, job_id))
             .await?;
         self.with_timeout::<_, ()>(conn.zrem(&available_key, job_id))
+            .await?;
+        self.with_timeout::<_, ()>(conn.zrem(&by_queue_key, job_id))
             .await?;
         self.with_timeout::<_, ()>(conn.hincr(&counts_key, &state_str, -1))
             .await?;
@@ -276,6 +301,7 @@ impl RedisStorage {
             local available_key = KEYS[3]
             local job_key_prefix = KEYS[4]
             local counts_key = KEYS[5]
+            local by_queue_prefix = KEYS[6]
             local from_state_name = ARGV[1]
             local from_state_variant = ARGV[2]
             local time_field = ARGV[3]
@@ -333,7 +359,13 @@ impl RedisStorage {
                 redis.call('SET', job_key, new_data)
                 redis.call('SREM', from_state_key, entry.id)
                 redis.call('SADD', to_state_key, entry.id)
-                redis.call('ZADD', available_key, tostring(entry.priority), entry.id)
+                -- Maintain both the global available ZSET and the
+                -- per-queue ZSET so queue-scoped fetch_and_lock_job
+                -- finds these promotions immediately. Same score on
+                -- both indices keeps them in sync.
+                local score = tostring(entry.priority)
+                redis.call('ZADD', available_key, score, entry.id)
+                redis.call('ZADD', by_queue_prefix .. job.queue, score, entry.id)
                 redis.call('HINCRBY', counts_key, from_state_name, -1)
                 redis.call('HINCRBY', counts_key, 'enqueued', 1)
                 table.insert(claimed, new_data)
@@ -347,6 +379,7 @@ impl RedisStorage {
         let available_key = self.available_jobs_key();
         let job_key_prefix = format!("{}:jobs:", self.config.key_prefix);
         let counts_key = self.job_counts_key();
+        let by_queue_prefix = format!("{}:available:", self.config.key_prefix);
         let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
 
         let result: Vec<String> = redis::Script::new(lua_script)
@@ -355,6 +388,7 @@ impl RedisStorage {
             .key(&available_key)
             .key(&job_key_prefix)
             .key(&counts_key)
+            .key(&by_queue_prefix)
             .arg(from_state_str)
             .arg(from_state_variant)
             .arg(time_field)
@@ -420,8 +454,9 @@ impl MonitoringApi for RedisStorage {
         //   1. job key (full)
         //   2. state index prefix
         //   3. all_jobs key
-        //   4. available ZSET
+        //   4. global available ZSET
         //   5. counts hash
+        //   6. per-queue available prefix (e.g. "qml:available:")
         //
         // ARGV:
         //   1. new state name (lowercase, e.g. "enqueued")
@@ -436,6 +471,7 @@ impl MonitoringApi for RedisStorage {
             local all_jobs_key = KEYS[3]
             local available_key = KEYS[4]
             local counts_key = KEYS[5]
+            local by_queue_prefix = KEYS[6]
             local new_state_name = ARGV[1]
             local new_blob = ARGV[2]
             local new_score = ARGV[3]
@@ -463,6 +499,11 @@ impl MonitoringApi for RedisStorage {
             end
 
             local job_id = old_job.id
+            -- Resolve the per-queue available key from the persisted
+            -- queue. The queue is stable for a job's lifetime, so even
+            -- when the job has just changed state, `old_job.queue` is
+            -- the same queue the new blob will land in.
+            local by_queue_key = by_queue_prefix .. old_job.queue
 
             redis.call('SET', job_key, new_blob)
             redis.call('SADD', all_jobs_key, job_id)
@@ -476,8 +517,10 @@ impl MonitoringApi for RedisStorage {
 
             if new_available == '1' then
                 redis.call('ZADD', available_key, tonumber(new_score), job_id)
+                redis.call('ZADD', by_queue_key, tonumber(new_score), job_id)
             else
                 redis.call('ZREM', available_key, job_id)
+                redis.call('ZREM', by_queue_key, job_id)
             end
 
             return 'ok'
@@ -493,6 +536,7 @@ impl MonitoringApi for RedisStorage {
         let all_jobs_key = self.all_jobs_key();
         let available_key = self.available_jobs_key();
         let counts_key = self.job_counts_key();
+        let by_queue_prefix = format!("{}:available:", self.config.key_prefix);
 
         let new_state_name = Self::state_to_string(&job.state);
         let (new_score, new_available) = if Self::is_job_available(job) {
@@ -509,6 +553,7 @@ impl MonitoringApi for RedisStorage {
             .key(&all_jobs_key)
             .key(&available_key)
             .key(&counts_key)
+            .key(&by_queue_prefix)
             .arg(&new_state_name)
             .arg(&new_blob)
             .arg(&new_score)
@@ -542,8 +587,9 @@ impl MonitoringApi for RedisStorage {
         //
         // KEYS[1] = job key (full)
         // KEYS[2] = state index prefix
-        // KEYS[3] = available ZSET
+        // KEYS[3] = global available ZSET
         // KEYS[4] = counts hash
+        // KEYS[5] = per-queue available prefix
         // ARGV[1] = expected variant string ("Enqueued" / "Failed" / …)
         // ARGV[2] = new variant string (for index swap)
         // ARGV[3] = new full job JSON to write
@@ -560,6 +606,7 @@ impl MonitoringApi for RedisStorage {
             local state_key_prefix = KEYS[2]
             local available_key = KEYS[3]
             local counts_key = KEYS[4]
+            local by_queue_prefix = KEYS[5]
             local expected_variant = ARGV[1]
             local new_variant = ARGV[2]
             local new_blob = ARGV[3]
@@ -576,6 +623,7 @@ impl MonitoringApi for RedisStorage {
             end
 
             local old_variant = expected_variant
+            local by_queue_key = by_queue_prefix .. job.queue
 
             redis.call('SET', job_key, new_blob)
             if old_variant ~= new_variant then
@@ -595,8 +643,10 @@ impl MonitoringApi for RedisStorage {
 
             if new_available == '1' then
                 redis.call('ZADD', available_key, tonumber(new_score), job.id)
+                redis.call('ZADD', by_queue_key, tonumber(new_score), job.id)
             else
                 redis.call('ZREM', available_key, job.id)
+                redis.call('ZREM', by_queue_key, job.id)
             end
 
             return 'ok'
@@ -611,6 +661,7 @@ impl MonitoringApi for RedisStorage {
         let state_key_prefix = format!("{}:state:", self.config.key_prefix);
         let available_key = self.available_jobs_key();
         let counts_key = self.job_counts_key();
+        let by_queue_prefix = format!("{}:available:", self.config.key_prefix);
 
         let new_kind = job.state.kind();
         let new_variant = new_kind.name();
@@ -631,6 +682,7 @@ impl MonitoringApi for RedisStorage {
             .key(&state_key_prefix)
             .key(&available_key)
             .key(&counts_key)
+            .key(&by_queue_prefix)
             .arg(expected_variant)
             .arg(new_variant)
             .arg(&new_blob)
@@ -924,155 +976,153 @@ impl Storage for RedisStorage {
     ) -> Result<Option<Job>, StorageError> {
         let mut conn = self.get_connection().await?;
 
-        // Lua script for atomic job fetching and locking.
+        // Atomic claim across one or more candidate ZSETs.
+        //
+        // For each candidate ZSET, peek at the top entry (highest score
+        // = highest priority + most-recent created_at) and pick the
+        // global maximum across all candidates. This naturally
+        // preserves cross-queue priority ordering when scanning
+        // multiple per-queue ZSETs without scanning past ineligible
+        // jobs (the previous version capped at 1024 candidates from
+        // a single global ZSET, which could miss eligible jobs in
+        // adversarial filter conditions).
         //
         // KEYS:
-        //   1. available jobs ZSET key (full)
-        //   2. job key prefix (e.g. "qml:jobs:") — concatenated with the
-        //      job id to form the full job key
-        //   3. state index key prefix (e.g. "qml:state:") — concatenated
-        //      with the state name (e.g. "enqueued") to form the full key
-        //   4. counts hash key (full)
+        //   1. job key prefix (e.g. "qml:jobs:") — concat with id for
+        //      the full job key.
+        //   2. state index prefix (e.g. "qml:state:") — concat with the
+        //      lowercase variant name (e.g. "enqueued") for the index.
+        //   3. counts hash key (full).
+        //   4. global available ZSET key — always cleaned up after a
+        //      claim, regardless of which candidate matched.
+        //   5. per-queue available prefix (e.g. "qml:available:") —
+        //      concat with the job's queue for the per-queue ZSET to
+        //      clean up after a claim.
+        //   6..   candidate ZSET keys to scan. With a queue filter
+        //         these are per-queue keys; without, this is just
+        //         [global_available_key].
         //
         // ARGV:
         //   1. worker_id
         //   2. now_iso — RFC3339 timestamp string for both
-        //      JobState::Processing.started_at and Job.updated_at. Passed
-        //      from Rust so the JSON timestamps round-trip through
-        //      `chrono::DateTime<Utc>` cleanly (cjson can't format dates).
-        //   3. queue filter as a JSON array, or "" for no filter
-        //   4. candidate cap — upper bound on entries scanned from the
-        //      available ZSET. Without a queue filter we only need 1.
-        //      With a filter we may need to scan past ineligible jobs.
+        //      JobState::Processing.started_at and Job.updated_at.
         let lua_script = r#"
-            local available_key = KEYS[1]
-            local job_key_prefix = KEYS[2]
-            local state_key_prefix = KEYS[3]
-            local counts_key = KEYS[4]
+            local job_key_prefix = KEYS[1]
+            local state_key_prefix = KEYS[2]
+            local counts_key = KEYS[3]
+            local global_available_key = KEYS[4]
+            local by_queue_prefix = KEYS[5]
             local worker_id = ARGV[1]
             local now_iso = ARGV[2]
-            local queue_filter_json = ARGV[3]
-            local cap = tonumber(ARGV[4])
 
-            local filter_set = nil
-            if queue_filter_json ~= '' then
-                local arr = cjson.decode(queue_filter_json)
-                if #arr > 0 then
-                    filter_set = {}
-                    for _, q in ipairs(arr) do
-                        filter_set[q] = true
+            -- Find the highest-score available job across the
+            -- candidate keys.
+            local best_id = nil
+            local best_score = -math.huge
+            for i = 6, #KEYS do
+                local top = redis.call('ZREVRANGE', KEYS[i], 0, 0, 'WITHSCORES')
+                if #top >= 2 then
+                    local id = top[1]
+                    local score = tonumber(top[2])
+                    if score and score > best_score then
+                        best_id = id
+                        best_score = score
                     end
                 end
             end
 
-            -- Pull a candidate batch ordered by score DESC (highest priority
-            -- first). Score is built in update_job_indices as
-            -- `priority + created_at_ms / 1e6` so higher score = higher
-            -- priority, with creation time breaking priority ties.
-            local candidates = redis.call(
-                'ZREVRANGEBYSCORE', available_key, '+inf', '-inf',
-                'LIMIT', 0, cap
-            )
-
-            for _, job_id in ipairs(candidates) do
-                local job_key = job_key_prefix .. job_id
-                local job_data = redis.call('GET', job_key)
-                if not job_data then
-                    -- Job was deleted; clean up the available set.
-                    redis.call('ZREM', available_key, job_id)
-                else
-                    -- JobState is externally tagged by serde, so the variant
-                    -- surfaces as a single key on job.state.
-                    local job = cjson.decode(job_data)
-                    local from_enqueued = job.state.Enqueued ~= nil
-                    local from_retry = job.state.AwaitingRetry ~= nil
-                    if not (from_enqueued or from_retry) then
-                        -- Stale entry in the available set; remove and move on.
-                        redis.call('ZREM', available_key, job_id)
-                    else
-                        local matches = (filter_set == nil) or filter_set[job.queue]
-                        if matches then
-                            local old_state_name
-                            if from_enqueued then
-                                old_state_name = 'enqueued'
-                            else
-                                old_state_name = 'awaiting_retry'
-                            end
-
-                            -- Mark job as processing, matching the
-                            -- externally-tagged layout so Rust can
-                            -- deserialize it back into JobState::Processing.
-                            -- Timestamps are passed as ISO strings because
-                            -- chrono's serde format is RFC3339 — feeding raw
-                            -- millis here would break deserialization.
-                            job.state = {
-                                Processing = {
-                                    worker_id = worker_id,
-                                    started_at = now_iso,
-                                    server_name = 'redis-storage'
-                                }
-                            }
-                            job.updated_at = now_iso
-
-                            local new_job_data = cjson.encode(job)
-                            redis.call('SET', job_key, new_job_data)
-                            redis.call('ZREM', available_key, job_id)
-                            redis.call('SREM', state_key_prefix .. old_state_name, job_id)
-                            redis.call('SADD', state_key_prefix .. 'processing', job_id)
-                            redis.call('HINCRBY', counts_key, old_state_name, -1)
-                            redis.call('HINCRBY', counts_key, 'processing', 1)
-
-                            return new_job_data
-                        end
-                    end
-                end
+            if not best_id then
+                return nil
             end
 
-            return nil
+            local job_key = job_key_prefix .. best_id
+            local job_data = redis.call('GET', job_key)
+            if not job_data then
+                -- Index drift: id present in a candidate set but no
+                -- job blob. Clean up everywhere we know about and bail.
+                for i = 6, #KEYS do
+                    redis.call('ZREM', KEYS[i], best_id)
+                end
+                redis.call('ZREM', global_available_key, best_id)
+                return nil
+            end
+
+            local job = cjson.decode(job_data)
+            local from_enqueued = job.state.Enqueued ~= nil
+            local from_retry = job.state.AwaitingRetry ~= nil
+            if not (from_enqueued or from_retry) then
+                -- Stale entry; the job has moved on but the index
+                -- didn't catch up. Clean and bail.
+                for i = 6, #KEYS do
+                    redis.call('ZREM', KEYS[i], best_id)
+                end
+                redis.call('ZREM', global_available_key, best_id)
+                return nil
+            end
+
+            local old_state_name = from_enqueued and 'enqueued' or 'awaiting_retry'
+
+            -- Transition to Processing.
+            job.state = {
+                Processing = {
+                    worker_id = worker_id,
+                    started_at = now_iso,
+                    server_name = 'redis-storage'
+                }
+            }
+            job.updated_at = now_iso
+
+            local new_job_data = cjson.encode(job)
+            redis.call('SET', job_key, new_job_data)
+            redis.call('ZREM', global_available_key, best_id)
+            redis.call('ZREM', by_queue_prefix .. job.queue, best_id)
+            redis.call('SREM', state_key_prefix .. old_state_name, best_id)
+            redis.call('SADD', state_key_prefix .. 'processing', best_id)
+            redis.call('HINCRBY', counts_key, old_state_name, -1)
+            redis.call('HINCRBY', counts_key, 'processing', 1)
+
+            return new_job_data
         "#;
 
-        let available_key = self.available_jobs_key();
         let job_key_prefix = format!("{}:jobs:", self.config.key_prefix);
         let state_key_prefix = format!("{}:state:", self.config.key_prefix);
         let counts_key = self.job_counts_key();
+        let global_available_key = self.available_jobs_key();
+        let by_queue_prefix = format!("{}:available:", self.config.key_prefix);
         let now_iso = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
 
-        // Bound how far the script will scan when filtering by queue. Without
-        // a filter we only need 1. With a filter, we may have to skip over
-        // ineligible-queue jobs to find one that matches; cap the scan to
-        // keep the script bounded. 1024 is well within Redis's default
-        // lua-time-limit and large enough to be effectively "all" for most
-        // realistic backlogs.
-        let cap = match queues {
-            Some(qs) if !qs.is_empty() => 1024,
-            _ => 1,
+        // Build the candidate-key list. With a queue filter, each
+        // configured queue gets its own per-queue ZSET as a candidate.
+        // Without a filter, we just scan the global ZSET. The script
+        // peeks at the top entry of each candidate and picks the
+        // global max — exact, no candidate cap.
+        let candidate_keys: Vec<String> = match queues {
+            Some(qs) if !qs.is_empty() => qs
+                .iter()
+                .map(|q| self.available_jobs_by_queue_key(q))
+                .collect(),
+            _ => vec![global_available_key.clone()],
         };
 
-        let queue_filter = match queues {
-            Some(qs) if !qs.is_empty() => serde_json::to_string(qs).map_err(|e| {
-                StorageError::serialization_with_source(
-                    "Failed to serialize queue filter",
-                    Box::new(e),
-                )
-            })?,
-            _ => String::new(),
-        };
-
-        let result: Option<String> = redis::Script::new(lua_script)
-            .key(&available_key)
+        let script = redis::Script::new(lua_script);
+        let mut invocation = script.prepare_invoke();
+        invocation
             .key(&job_key_prefix)
             .key(&state_key_prefix)
             .key(&counts_key)
-            .arg(worker_id)
-            .arg(&now_iso)
-            .arg(&queue_filter)
-            .arg(cap)
-            .invoke_async(&mut conn)
-            .await
-            .map_err(|e| StorageError::OperationFailed {
+            .key(&global_available_key)
+            .key(&by_queue_prefix);
+        for key in &candidate_keys {
+            invocation.key(key);
+        }
+        invocation.arg(worker_id).arg(&now_iso);
+
+        let result: Option<String> = invocation.invoke_async(&mut conn).await.map_err(|e| {
+            StorageError::OperationFailed {
                 message: format!("Failed to fetch and lock job: {}", e),
                 source: Some(Box::new(e)),
-            })?;
+            }
+        })?;
 
         if let Some(job_json) = result {
             let job: Job = serde_json::from_str(&job_json).map_err(|e| {

--- a/tests/named_lock_sweeper_test.rs
+++ b/tests/named_lock_sweeper_test.rs
@@ -1,0 +1,174 @@
+//! Cross-backend contract for `Storage::cleanup_expired_named_locks`.
+//!
+//! The Postgres backend's `qml_locks` table accumulates rows when a
+//! workload takes a lock once and never re-acquires (the takeover-on-
+//! acquire path in `try_acquire_lock` only fires on contention).
+//! `CleanupWorker` calls this method on every tick to keep the table
+//! bounded. Memory mirrors the Postgres semantics. Redis is a no-op
+//! because Redis-native PX TTL handles expiration server-side.
+
+use std::env;
+use std::time::Duration;
+
+use chrono::Utc;
+use qml_rs::storage::{MemoryStorage, Storage};
+
+#[cfg(feature = "postgres")]
+fn database_url() -> Option<String> {
+    env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::var("POSTGRES_URL").ok())
+}
+
+#[cfg(feature = "redis")]
+fn redis_url() -> Option<String> {
+    env::var("REDIS_URL").ok()
+}
+
+#[tokio::test]
+async fn memory_sweeper_removes_only_expired_named_locks() {
+    let storage = MemoryStorage::new();
+
+    // Live lock — 30s ahead.
+    storage
+        .try_acquire_lock("live", "owner-a", Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    // Short-lived lock — 50ms.
+    storage
+        .try_acquire_lock("expired", "owner-b", Duration::from_millis(50))
+        .await
+        .unwrap();
+
+    // Wait past the short TTL.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let removed = storage
+        .cleanup_expired_named_locks(Utc::now())
+        .await
+        .unwrap();
+    assert_eq!(removed, 1, "exactly one lock should be expired and removed");
+
+    // The live lock is still held by owner-a — a peer attempt is rejected.
+    assert!(
+        !storage
+            .try_acquire_lock("live", "peer", Duration::from_secs(30))
+            .await
+            .unwrap(),
+        "live lock should still reject a peer after the sweep"
+    );
+
+    // The expired lock is now free.
+    assert!(
+        storage
+            .try_acquire_lock("expired", "owner-c", Duration::from_secs(30))
+            .await
+            .unwrap(),
+        "expired-and-swept lock should be acquirable by a new owner"
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_sweeper_deletes_expired_rows() {
+    use qml_rs::storage::{PostgresConfig, PostgresStorage};
+
+    let Some(url) = database_url() else {
+        eprintln!("DATABASE_URL not set; skipping postgres sweeper test");
+        return;
+    };
+    let config = PostgresConfig::new().with_database_url(&url);
+    let storage = match PostgresStorage::new(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping postgres sweeper test: {e}");
+            return;
+        }
+    };
+    if let Err(e) = storage.migrate().await {
+        eprintln!("skipping postgres sweeper test: migrate failed: {e}");
+        return;
+    }
+
+    // Unique resource names so concurrent test runs don't collide.
+    let suffix = uuid::Uuid::new_v4();
+    let live = format!("pg-sweep-live-{suffix}");
+    let expired = format!("pg-sweep-expired-{suffix}");
+
+    storage
+        .try_acquire_lock(&live, "owner-a", Duration::from_secs(60))
+        .await
+        .unwrap();
+    storage
+        .try_acquire_lock(&expired, "owner-b", Duration::from_secs(1))
+        .await
+        .unwrap();
+
+    // Sweep with a `now` deliberately in the future so the test isn't
+    // sensitive to clock skew between Rust and the Postgres server. The
+    // expired lock has a 1s TTL; we sweep 5s ahead so it's
+    // unambiguously past expiry while the 60s live lock isn't.
+    let sweep_now = Utc::now() + chrono::Duration::seconds(5);
+    let removed = storage
+        .cleanup_expired_named_locks(sweep_now)
+        .await
+        .unwrap();
+    assert!(
+        removed >= 1,
+        "sweeper must report at least one removed row (got {removed})"
+    );
+
+    // Live lock survives.
+    assert!(
+        !storage
+            .try_acquire_lock(&live, "peer", Duration::from_secs(30))
+            .await
+            .unwrap(),
+        "live lock should still reject a peer after the sweep"
+    );
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_sweeper_is_noop() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis sweeper test");
+        return;
+    };
+    let prefix = format!("nls-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis sweeper test: {e}");
+            return;
+        }
+    };
+
+    // Acquire and immediately let it expire — Redis PX cleans it up
+    // server-side without our help.
+    storage
+        .try_acquire_lock("redis-sweep", "owner", Duration::from_millis(50))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Per the contract, redis returns Ok(0) — the server already
+    // expired the key, so the cleanup primitive has no work to do.
+    let removed = storage
+        .cleanup_expired_named_locks(Utc::now())
+        .await
+        .unwrap();
+    assert_eq!(removed, 0, "redis sweeper must report zero work");
+
+    // And the lock is genuinely gone — a fresh acquire succeeds.
+    assert!(
+        storage
+            .try_acquire_lock("redis-sweep", "another-owner", Duration::from_secs(30))
+            .await
+            .unwrap()
+    );
+}

--- a/tests/queue_filter_test.rs
+++ b/tests/queue_filter_test.rs
@@ -238,3 +238,57 @@ async fn postgres_queue_filter_no_filter_returns_all() {
     let qb = format!("pgnf-b-{suffix}");
     exercise_no_filter(&storage, &qa, &qb).await;
 }
+
+/// Regression: with the previous bounded-candidate-cap implementation
+/// of `fetch_and_lock_job`, a Redis worker scoped to queue `target`
+/// could miss eligible jobs when more than 1024 ineligible-queue jobs
+/// were enqueued ahead of them. The per-queue ZSET design reads only
+/// the per-queue keys named in the filter, so cross-queue depth no
+/// longer matters.
+#[cfg(feature = "redis")]
+#[tokio::test]
+async fn redis_queue_filter_finds_eligible_past_old_1024_cap() {
+    use qml_rs::storage::{RedisConfig, RedisStorage};
+
+    let Some(url) = redis_url() else {
+        eprintln!("REDIS_URL not set; skipping redis cap-removal test");
+        return;
+    };
+
+    let prefix = format!("qf-cap-{}", uuid::Uuid::new_v4());
+    let config = RedisConfig::new().with_url(&url).with_key_prefix(&prefix);
+    let storage = match RedisStorage::with_config(config).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping redis cap-removal test: {e}");
+            return;
+        }
+    };
+
+    // 1500 jobs in the noise queue (>1024 — the old cap).
+    let noise_queue = "redcap-noise";
+    let target_queue = "redcap-target";
+    for _ in 0..1500 {
+        storage.enqueue(&job_in(noise_queue)).await.unwrap();
+    }
+
+    // One job in the target queue — must be findable by a worker
+    // scoped to that queue, regardless of how many noise-queue jobs
+    // are in front of it in any global ordering.
+    let target = job_in(target_queue);
+    let target_id = target.id.clone();
+    storage.enqueue(&target).await.unwrap();
+
+    let only_target = vec![target_queue.to_string()];
+    let claimed = storage
+        .fetch_and_lock_job("worker-target", Some(&only_target))
+        .await
+        .unwrap();
+
+    let claimed = claimed.expect(
+        "queue-scoped worker must find the target job past the >1024 noise jobs — the \
+         per-queue ZSET design should make cross-queue depth irrelevant",
+    );
+    assert_eq!(claimed.id, target_id);
+    assert_eq!(claimed.queue, target_queue);
+}


### PR DESCRIPTION
Second batch from the principal-engineer code review. Cashes in two follow-ups explicitly promised in #23 (per-queue ZSETs and `StorageError` consolidation) and lands two real correctness/perf items (Postgres hot-path indexes, `qml_locks` sweeper).

Each commit is self-contained and was verified individually before stacking. Full suite (172/172 tests) green at the tip.

## What landed

**perf(postgres): hot-path partial indexes** (`10d553c`) — closes review C5.
The pre-existing indexes covered each column in isolation but missed the actual access patterns. Three new partial indexes:
* `idx_qml_jobs_fetch (queue_name, priority DESC, created_at ASC) WHERE state_name IN ('enqueued','awaiting_retry')` — covers the `fetch_and_lock_job` / `claim_due_*` hot path exactly, in claim order.
* `idx_qml_jobs_due_scheduled` — expression index over `qml.parse_iso_utc(state_data->'Scheduled'->>'enqueue_at')` with the same predicate-aligned columns.
* `idx_qml_jobs_due_retry` — mirror for `AwaitingRetry`.

Expression indexes can't use `text::timestamptz` directly (that cast is STABLE — Postgres rejects it in indexes). Worked around with an `IMMUTABLE` helper function `qml.parse_iso_utc(text) RETURNS timestamptz` that wraps `($1::timestamp AT TIME ZONE 'UTC')`. Marked IMMUTABLE on the basis that every writer in the codebase emits explicit-UTC timestamps (chrono's `Z`, Lua's `to_rfc3339_opts(Micros, true)`, Postgres `to_jsonb(NOW())` `+00:00`) — all parse to the same UTC instant regardless of session timezone. Updated 5 query predicates to call the helper symmetrically so the planner matches the indexes. Also dropped a duplicate `idx_qml_jobs_job_type` definition.

**fix(storage): `cleanup_expired_named_locks` + wire into CleanupWorker** (`4fb0e62`) — closes review C4.
The Postgres `qml_locks` table accumulated rows for one-shot lock workloads (the takeover path in `try_acquire_lock` only fires on contention; one-shot locks never re-acquired). New `Storage::cleanup_expired_named_locks(now)` method:
* **Postgres**: `DELETE FROM qml.qml_locks WHERE expires_at < $1` (backed by the existing `idx_qml_locks_expires_at`).
* **Memory**: `HashMap::retain` over the in-process map.
* **Redis**: no-op `Ok(0)` — server-side PX TTL already handles it.

Wired into `CleanupWorker::sweep_once` with a shared `now`. A failed lock sweep doesn't poison the tick.

**refactor(error): consolidate duplicate `StorageError` variants** (`d58828b`) — closes the consolidation follow-up promised in #23.
The enum carried both a canonical shape (`Connection`, `Serialization`, `OperationFailed`) and a parallel source-bearing shorthand (`ConnectionError`, `SerializationError`, `DeserializationError`, `OperationError`). Same fields, same routing through the `From<StorageError> for QmlError` impl — pure maintenance burden. Folded:
* `ConnectionError` → `Connection`
* `SerializationError` → `Serialization`
* `DeserializationError` → new `Deserialization` variant (distinct read-vs-write semantics)
* `OperationError` → `OperationFailed`

Also dropped the `operation: String` field from `OperationFailed` — its 5 callers folded the operation name into the message (which already contained operation context). Helpers (`connection`, `serialization`, `deserialization` (new), `operation_failed`, plus `*_with_source` and `conn_err`/`ser_err`/`de_err`/`op_err`) all build canonical variants now.

**fix(redis): per-queue available ZSETs eliminate the 1024-cap** (`f33149e`) — closes the per-queue-ZSETs follow-up promised in #23.
`fetch_and_lock_job`'s previous Lua scanned a single global `qml:available` ZSET, capped at 1024 candidates with a queue filter — pathological setups (>1024 ineligible-queue jobs ahead of an eligible one) would let queue-scoped workers see `Ok(None)` despite having work. New design:
* Maintain `qml:available:<queue>` ZSETs alongside the global `qml:available`. The job's `queue` is stable for its lifetime, so a single per-queue key per job.
* Both indices are updated in lockstep at every write site: `update_job_indices`, `remove_job_indices`, the `update_if_state` Lua, and the `claim_due_jobs_lua` Lua.
* Rewrote `fetch_and_lock_job`'s Lua to take a list of candidate ZSET keys and pick the global max-score across them. No filter → candidates `= [global]`. With filter → candidates `= [qml:available:q1, qml:available:q2, ...]`. Cross-queue priority ordering is preserved by picking the global max.

Regression test enqueues 1500 noise-queue jobs (>1024, the old cap) plus a single target-queue job and proves a target-scoped worker still claims it.

## Breaking changes (callout for downstream)

* **`StorageError` shorthand variants removed.** Pattern matches like `StorageError::DeserializationError { message }` need to switch to `StorageError::Deserialization { message, .. }` (note the new `Deserialization` variant; the previous canonical `Serialization` is unchanged for write-failure paths).
* **`StorageError::OperationFailed` no longer has an `operation: String` field.** Match arms must drop it; the helper constructors take only `(message[, source])` now. Operation context already lived in `message` for every in-tree caller.
* **Three new `qml.*` Postgres objects.** `qml.parse_iso_utc(text) RETURNS timestamptz` IMMUTABLE function plus the three partial indexes. Auto-installed on first migrate; existing 1.x deployments need to call `storage.migrate()` once after upgrading or run the new `CREATE INDEX IF NOT EXISTS` statements manually (each can be wrapped in `CONCURRENTLY` for downtime-sensitive deploys).
* **New `Storage::cleanup_expired_named_locks` required trait method.** Anyone with a custom `Storage` impl outside this crate must add it. The three in-tree backends (`MemoryStorage`, `RedisStorage`, `PostgresStorage`) plus `StorageInstance` are all updated.
* **Redis index layout.** `qml:available:<queue>` keys are new; `qml:available` keeps its previous semantics. On upgrade against an existing 1.x Redis deployment, jobs in the old global ZSET are still picked up by the no-filter path, but queue-scoped workers won't find them until those jobs cycle through the new `update_job_indices` (e.g. via a state transition or a re-enqueue). For a clean cutover, FLUSHDB the QML keys or let the existing jobs drain naturally.

## New tests

* `tests/named_lock_sweeper_test.rs` — cross-backend contract for `cleanup_expired_named_locks` (memory + redis + postgres).
* `tests/queue_filter_test.rs::redis_queue_filter_finds_eligible_past_old_1024_cap` — regression that would have failed under the old bounded-candidate-cap implementation.

## Test plan

- [x] `cargo build --all-features --all-targets` clean.
- [x] `cargo fmt` applied.
- [x] `cargo test --all-targets --no-fail-fast` (default features) — every test binary green.
- [x] Full suite single-threaded with Redis + Postgres up, `--all-features`: 172/172 tests pass.
- [x] Migration verified end-to-end via `postgres_upgrade_test` (auto-migrate from 1.0.1 with the new indexes + helper function).
- [x] Reviewer to spot-check the rewritten `fetch_and_lock_job` Lua for cross-queue priority ordering edge cases.
- [x] Reviewer to confirm `qml.parse_iso_utc` IMMUTABLE marking is acceptable (depends on the codebase-wide invariant that all timestamps in `state_data` are explicit-UTC; documented in install.sql comment).

## What's still deliberately out of scope

- **I1+I2 from the original review** — splitting `Storage` into 5 cohesive sub-traits (`JobStore + JobLocker + RecurringStore + ServerRegistry + NamedLocks`) and retiring the `StorageInstance` enum (350+ lines of dispatch boilerplate) for `Arc<dyn Storage>`. Real architectural refactor, planned for batch 3.
- **Postgres `update_if_state` single-statement CTE** — would save one round-trip on the mismatch path. Dashboard retry is human-triggered; the latency saving doesn't justify the complexity here.