### PR TITLE
Code review batch 4: final polish — N1, N2, N3, N6, I7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ axum = { version = "0.8.4", features = ["ws"], optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6.6", features = ["cors", "fs"], optional = true }
 futures-util = { version = "0.3", optional = true }
+# Replace hand-rolled base64 / constant-time-eq in dashboard/auth.rs with
+# audited implementations. `subtle` is a drop-in for the constant-time
+# comparison; `base64` (engine API) replaces the bespoke decoder.
+base64 = { version = "0.22", optional = true }
+subtle = { version = "2.6", optional = true }
 
 # PostgreSQL storage support
 sqlx = { version = "0.8", features = [
@@ -63,7 +68,14 @@ postgres = ["sqlx"]
 redis = ["dep:redis"]
 # Built-in HTTP dashboard (axum + tower + WebSocket UI). Off by default so
 # headless workers don't pay the compile cost of pulling in axum/tower.
-dashboard = ["dep:axum", "dep:tower", "dep:tower-http", "dep:futures-util"]
+dashboard = [
+    "dep:axum",
+    "dep:tower",
+    "dep:tower-http",
+    "dep:futures-util",
+    "dep:base64",
+    "dep:subtle",
+]
 # Prometheus metrics: provides a `PrometheusMetrics` registry + a
 # `PrometheusMiddleware` for the F1 middleware stack, plus a `/metrics`
 # route on the dashboard when combined with the `dashboard` feature.

--- a/examples/axum_integration.rs
+++ b/examples/axum_integration.rs
@@ -85,9 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🚀 Starting Axum + QML Integration Example");
 
     // Initialize QML storage - this will NOT panic thanks to our fixes!
-    let storage_config = MemoryConfig::new()
-        .with_max_jobs(1000)
-        .with_auto_cleanup(true);
+    let storage_config = MemoryConfig::new().with_max_jobs(1000);
 
     let storage = StorageInstance::memory_with_config(storage_config);
 

--- a/examples/storage_demo.rs
+++ b/examples/storage_demo.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("📦 Demo 2: Memory Storage (Custom Configuration)");
     println!("-------------------------------------------------");
 
-    let memory_config = MemoryConfig::new()
-        .with_max_jobs(1000)
-        .with_auto_cleanup(true);
+    let memory_config = MemoryConfig::new().with_max_jobs(1000);
     let custom_memory_storage = StorageInstance::memory_with_config(memory_config);
     demo_storage_operations(&custom_memory_storage, "Memory Storage (Custom)").await?;
     println!();

--- a/src/core/job_state.rs
+++ b/src/core/job_state.rs
@@ -161,6 +161,15 @@ impl JobState {
             (Processing { .. }, Succeeded { .. }) => true,
             (Processing { .. }, Failed { .. }) => true,
             (Processing { .. }, Deleted { .. }) => true,
+            // The retry path used to require a two-step
+            // `Processing → Failed → AwaitingRetry`, with the
+            // intermediate `Failed` never reaching storage. That was
+            // fragile — a panic between the two `set_state` calls
+            // left the in-memory job in a state callers couldn't
+            // distinguish from a real terminal failure. Allow the
+            // direct transition so `JobProcessor::handle_job_retry`
+            // can be a single hop.
+            (Processing { .. }, AwaitingRetry { .. }) => true,
 
             // From Scheduled
             (Scheduled { .. }, Enqueued { .. }) => true,

--- a/src/dashboard/auth.rs
+++ b/src/dashboard/auth.rs
@@ -176,11 +176,17 @@ fn authority_of(url: &str) -> Option<String> {
 /// version was a 25-line hand-rolled implementation; the crate
 /// version is audited, handles padding edge cases the same way, and
 /// keeps the dashboard off custom decoding code.
+///
+/// The input is passed through verbatim — the crate handles the `=`
+/// padding internally. The previous hand-rolled implementation called
+/// `input.trim_end_matches('=')` (stripping padding), and a brief
+/// intermediate of this function called `.trim()` (stripping
+/// surrounding whitespace) which would have widened the contract; the
+/// only caller (`check_basic`) already trims its input, so this
+/// matches the old strict-format behavior.
 fn base64_decode(input: &str) -> Option<Vec<u8>> {
     use base64::Engine as _;
-    base64::engine::general_purpose::STANDARD
-        .decode(input.trim())
-        .ok()
+    base64::engine::general_purpose::STANDARD.decode(input).ok()
 }
 
 #[cfg(test)]

--- a/src/dashboard/auth.rs
+++ b/src/dashboard/auth.rs
@@ -145,15 +145,16 @@ fn check_bearer(header_value: &str, expected: &str) -> bool {
     constant_time_eq(token.trim().as_bytes(), expected.as_bytes())
 }
 
+/// Length-tolerant constant-time equality, delegated to the `subtle`
+/// crate. The earlier hand-rolled XOR-fold did the right thing but the
+/// audited version is simpler to reason about and keeps the dashboard
+/// off custom crypto code.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
     if a.len() != b.len() {
         return false;
     }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+    a.ct_eq(b).into()
 }
 
 /// Extract the authority (`host[:port]`) from a URL. Returns `None` if the
@@ -169,31 +170,17 @@ fn authority_of(url: &str) -> Option<String> {
     }
 }
 
+/// Standard Base64 decoder for the `Authorization: Basic ...` header.
+///
+/// Delegated to the `base64` crate's standard engine. The earlier
+/// version was a 25-line hand-rolled implementation; the crate
+/// version is audited, handles padding edge cases the same way, and
+/// keeps the dashboard off custom decoding code.
 fn base64_decode(input: &str) -> Option<Vec<u8>> {
-    fn val(c: u8) -> Option<u32> {
-        match c {
-            b'A'..=b'Z' => Some((c - b'A') as u32),
-            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
-            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
-            b'+' => Some(62),
-            b'/' => Some(63),
-            _ => None,
-        }
-    }
-    let input = input.trim_end_matches('=').as_bytes();
-    let mut out = Vec::with_capacity(input.len() * 3 / 4);
-    let mut buf: u32 = 0;
-    let mut bits: u8 = 0;
-    for &c in input {
-        buf = (buf << 6) | val(c)?;
-        bits += 6;
-        if bits >= 8 {
-            bits -= 8;
-            out.push((buf >> bits) as u8);
-            buf &= (1u32 << bits) - 1;
-        }
-    }
-    Some(out)
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD
+        .decode(input.trim())
+        .ok()
 }
 
 #[cfg(test)]

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -250,9 +250,20 @@ impl DashboardServer {
             ));
         }
 
-        // Stitch the unguarded /metrics route in *after* the auth
-        // layer if `metrics_skip_auth` is set, so it bypasses the
-        // auth middleware entirely.
+        // Stitch the unguarded `/metrics` route in *after* the auth
+        // layer is applied to `guarded`, when `metrics_skip_auth` is
+        // on. Axum's middleware semantics make this the right shape:
+        // `Router::layer` wraps only the routes already in that
+        // router, and `Router::merge` combines two routers without
+        // re-applying either side's middleware to the other side. The
+        // result is exactly the split we want — guarded routes still
+        // hit auth, the merged-in `/metrics` doesn't.
+        //
+        // It's worth a comment because the visual order
+        // (`.layer(auth)` then `.merge(unguarded)`) reads like the
+        // auth applies to everything, which axum's docs explicitly
+        // disclaim. The two `metrics_route_*_when_skip_auth_*` tests
+        // in `metrics_route_tests` lock down both shapes.
         let mut app = guarded;
         #[cfg(feature = "metrics")]
         if let Some(unguarded) = unguarded_metrics_router {

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -38,13 +38,26 @@ pub struct DashboardConfig {
     pub auth: Option<DashboardAuth>,
     /// Optional Prometheus metrics handle. When set, the dashboard exposes
     /// a `GET /metrics` endpoint returning the Prometheus text exposition
-    /// format over the shared [`PrometheusMetrics`] registry. The route
-    /// inherits the same auth guard as the rest of the dashboard — scrapers
-    /// that can't authenticate should scrape via a sidecar on the loopback.
+    /// format over the shared [`PrometheusMetrics`] registry.
+    ///
+    /// By default the route inherits the same auth guard as the rest of
+    /// the dashboard. Toggle [`metrics_skip_auth`](Self::metrics_skip_auth)
+    /// to true to expose `/metrics` without authentication — useful when
+    /// a Prometheus scraper can't speak Basic/Bearer and the dashboard
+    /// is bound to a loopback or otherwise-firewalled interface.
     ///
     /// Requires the `metrics` cargo feature.
     #[cfg(feature = "metrics")]
     pub metrics: Option<Arc<PrometheusMetrics>>,
+    /// When true, the `/metrics` route is mounted *outside* the auth
+    /// middleware so Prometheus scrapers can read it without
+    /// credentials. The CSRF guard is unaffected (and a no-op for
+    /// `GET` regardless). Defaults to false — opt in explicitly.
+    ///
+    /// Only meaningful when [`metrics`](Self::metrics) is `Some` and
+    /// the `metrics` cargo feature is enabled.
+    #[cfg(feature = "metrics")]
+    pub metrics_skip_auth: bool,
 }
 
 impl Default for DashboardConfig {
@@ -56,6 +69,8 @@ impl Default for DashboardConfig {
             auth: None,
             #[cfg(feature = "metrics")]
             metrics: None,
+            #[cfg(feature = "metrics")]
+            metrics_skip_auth: false,
         }
     }
 }
@@ -190,30 +205,58 @@ impl DashboardServer {
             .route("/queues", get(dashboard_ui))
             .route("/statistics", get(dashboard_ui));
 
-        let mut app = Router::new()
+        // Routes that *always* sit under the auth guard.
+        let mut guarded = Router::new()
             .merge(api_router)
             .merge(ws_router)
             .merge(ui_router);
 
+        // The /metrics route can land on either the guarded router (the
+        // default — inherits auth) or a separate unguarded router when
+        // `metrics_skip_auth` is set. Hold it in an Option so the auth
+        // layering below stays linear.
         #[cfg(feature = "metrics")]
-        if let Some(metrics) = self.config.metrics.clone() {
-            let metrics_router = Router::new()
+        let metrics_router = self.config.metrics.clone().map(|metrics| {
+            Router::new()
                 .route("/metrics", get(metrics_handler))
-                .with_state(metrics);
-            app = app.merge(metrics_router);
+                .with_state(metrics)
+        });
+
+        #[cfg(feature = "metrics")]
+        let unguarded_metrics_router = match &metrics_router {
+            Some(_) if self.config.metrics_skip_auth => metrics_router.clone(),
+            _ => None,
+        };
+
+        #[cfg(feature = "metrics")]
+        if let Some(metrics_router) = metrics_router.clone() {
+            // If skip-auth is off, fold metrics into the guarded set so
+            // auth applies just like every other route.
+            if !self.config.metrics_skip_auth {
+                guarded = guarded.merge(metrics_router);
+            }
         }
 
         // DB4: same-origin guard on state-changing methods. Applied before
         // auth so cross-site mutation attempts are rejected without leaking
         // an auth challenge.
-        app = app.layer(middleware::from_fn(auth::csrf_guard));
+        guarded = guarded.layer(middleware::from_fn(auth::csrf_guard));
 
-        // DB2: optional auth guard on every route.
+        // DB2: optional auth guard on every guarded route.
         if let Some(auth) = &self.config.auth {
-            app = app.layer(middleware::from_fn_with_state(
+            guarded = guarded.layer(middleware::from_fn_with_state(
                 Arc::new(auth.clone()),
                 auth::require_auth,
             ));
+        }
+
+        // Stitch the unguarded /metrics route in *after* the auth
+        // layer if `metrics_skip_auth` is set, so it bypasses the
+        // auth middleware entirely.
+        let mut app = guarded;
+        #[cfg(feature = "metrics")]
+        if let Some(unguarded) = unguarded_metrics_router {
+            app = app.merge(unguarded);
         }
 
         app.layer(
@@ -702,5 +745,100 @@ mod metrics_route_tests {
         let body = std::str::from_utf8(&body_bytes).unwrap();
         assert!(body.contains("qml_jobs_enqueued_total"));
         assert!(body.contains("queue=\"default\""));
+    }
+
+    /// Build the full DashboardServer router and exercise it with
+    /// `tower::ServiceExt::oneshot`. Verifies that
+    /// `metrics_skip_auth = true` lets `/metrics` through without
+    /// credentials while the rest of the routes still demand them.
+    async fn server_router(config: DashboardConfig) -> Router {
+        use crate::storage::MemoryStorage;
+        let storage = Arc::new(MemoryStorage::new());
+        let server = DashboardServer::new(storage, config);
+        server.create_app().await
+    }
+
+    #[tokio::test]
+    async fn metrics_route_inherits_auth_when_skip_auth_is_false() {
+        let metrics = PrometheusMetrics::new().expect("registry");
+        let config = DashboardConfig {
+            host: "127.0.0.1".into(),
+            port: 0,
+            statistics_update_interval: 60,
+            auth: Some(crate::dashboard::auth::DashboardAuth::Basic {
+                username: "u".to_string(),
+                password: "p".to_string(),
+            }),
+            metrics: Some(metrics),
+            metrics_skip_auth: false,
+        };
+
+        let app = server_router(config).await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "default config should require auth on /metrics"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_route_skips_auth_when_skip_auth_is_true() {
+        let metrics = PrometheusMetrics::new().expect("registry");
+        let config = DashboardConfig {
+            host: "127.0.0.1".into(),
+            port: 0,
+            statistics_update_interval: 60,
+            auth: Some(crate::dashboard::auth::DashboardAuth::Basic {
+                username: "u".to_string(),
+                password: "p".to_string(),
+            }),
+            metrics: Some(metrics),
+            metrics_skip_auth: true,
+        };
+
+        let app = server_router(config).await;
+
+        // /metrics is reachable without credentials.
+        let metrics_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            metrics_resp.status(),
+            StatusCode::OK,
+            "metrics_skip_auth=true should let /metrics through without credentials"
+        );
+
+        // Other routes still demand auth.
+        let api_resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/jobs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            api_resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "metrics_skip_auth must not weaken non-/metrics routes"
+        );
     }
 }

--- a/src/processing/processor.rs
+++ b/src/processing/processor.rs
@@ -343,19 +343,11 @@ impl JobProcessor {
             return self.fail_job_permanently(job, error, None).await;
         }
 
-        // Save the pre-retry state for the state-change hook. The state
-        // machine forces a two-step transition (Processing → Failed →
-        // AwaitingRetry), but the intermediate `Failed` is an artifact
-        // that never hits storage — observers should see one logical
-        // transition from whatever we were in directly to AwaitingRetry.
+        // Save the pre-retry state for the state-change hook so
+        // observers see one logical transition (whatever-we-were-in →
+        // AwaitingRetry), not the intermediate Failed step that
+        // earlier revisions had to dance through.
         let pre_retry_state = job.state.clone();
-
-        // First transition to Failed state (intermediate, not hooked)
-        let failed_state = JobState::failed(error.clone(), None);
-        if let Err(e) = job.set_state(failed_state) {
-            error!("Failed to set job state to Failed: {}", e);
-            return Err(e);
-        }
 
         // Calculate retry time — the retry policy counts attempts starting from
         // 1, and `job.attempt` already reflects the just-completed attempt, so
@@ -364,16 +356,19 @@ impl JobProcessor {
             .or_else(|| self.retry_policy.calculate_retry_time(job.attempt))
             .unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(60));
 
-        // Then transition to AwaitingRetry
+        // One-shot transition. The state machine permits
+        // `Processing → AwaitingRetry` directly (added when this code
+        // was simplified), so we no longer need the
+        // `Processing → Failed → AwaitingRetry` two-step which was
+        // fragile against a panic landing on the intermediate Failed.
         let retry_state = JobState::awaiting_retry(retry_time, &error);
-
         if let Err(e) = job.set_state(retry_state) {
             error!("Failed to set job state to AwaitingRetry: {}", e);
             return Err(e);
         }
 
         // Fire the hook with the saved pre-retry state so observers see
-        // the logical transition, not the intermediate Failed step.
+        // the logical transition.
         self.fire_state_change_hook(job, &pre_retry_state);
 
         // Update in storage

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -21,23 +21,46 @@ impl Default for StorageConfig {
     }
 }
 
-/// Configuration for in-memory storage
+/// Configuration for in-memory storage.
+///
+/// Earlier revisions carried `auto_cleanup` / `cleanup_interval` knobs
+/// here, but those were dead — `MemoryStorage` never read them, and
+/// final-state expiration is owned out-of-band by
+/// [`crate::processing::CleanupWorker`] which sweeps `expires_at` set
+/// by `JobProcessor`. The fields and their builders are kept as
+/// deprecated no-ops for one release so existing callers compile, but
+/// they don't influence runtime behavior.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryConfig {
     /// Maximum number of jobs to keep in memory
     pub max_jobs: Option<usize>,
-    /// Whether to enable auto-cleanup of completed jobs
+    /// **Deprecated.** Was a knob for in-process auto-cleanup, but
+    /// `MemoryStorage` never observed it and never will — cleanup is
+    /// owned by the cross-backend `CleanupWorker`. Kept to avoid
+    /// breaking downstream serializations that mention it. Will be
+    /// removed in the next major release.
+    #[deprecated(
+        note = "auto_cleanup is a no-op; CleanupWorker handles expiration. Will be removed."
+    )]
     pub auto_cleanup: bool,
-    /// Interval for cleanup operations
+    /// **Deprecated.** Same story as `auto_cleanup` — kept as a
+    /// compatibility shim. Will be removed.
+    #[deprecated(
+        note = "cleanup_interval is a no-op; configure CleanupWorker via ServerConfig instead."
+    )]
     pub cleanup_interval: Option<Duration>,
 }
 
 impl Default for MemoryConfig {
     fn default() -> Self {
+        // The deprecated fields are still initialized so the struct
+        // round-trips through serde for callers that have serialized
+        // old configs to disk.
+        #[allow(deprecated)]
         Self {
             max_jobs: Some(10_000),
             auto_cleanup: true,
-            cleanup_interval: Some(Duration::from_secs(300)), // 5 minutes
+            cleanup_interval: Some(Duration::from_secs(300)),
         }
     }
 }
@@ -60,15 +83,29 @@ impl MemoryConfig {
         self
     }
 
-    /// Enable auto-cleanup of completed jobs
+    /// **Deprecated.** No-op — see the field-level note on
+    /// [`MemoryConfig::auto_cleanup`].
+    #[deprecated(
+        note = "auto_cleanup is a no-op; CleanupWorker handles expiration. Will be removed."
+    )]
     pub fn with_auto_cleanup(mut self, enabled: bool) -> Self {
-        self.auto_cleanup = enabled;
+        #[allow(deprecated)]
+        {
+            self.auto_cleanup = enabled;
+        }
         self
     }
 
-    /// Set the cleanup interval
+    /// **Deprecated.** No-op — see the field-level note on
+    /// [`MemoryConfig::cleanup_interval`].
+    #[deprecated(
+        note = "cleanup_interval is a no-op; configure CleanupWorker via ServerConfig instead."
+    )]
     pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {
-        self.cleanup_interval = Some(interval);
+        #[allow(deprecated)]
+        {
+            self.cleanup_interval = Some(interval);
+        }
         self
     }
 }
@@ -393,7 +430,12 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_memory_config_default() {
+        // The deprecated `auto_cleanup` / `cleanup_interval` fields
+        // still need to default to a value because the struct has to
+        // round-trip through serde without dropping them. The runtime
+        // ignores them either way.
         let config = MemoryConfig::default();
         assert_eq!(config.max_jobs, Some(10_000));
         assert!(config.auto_cleanup);
@@ -401,7 +443,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_memory_config_builder() {
+        // Same back-compat shim as `test_memory_config_default`: the
+        // builders are deprecated no-ops but must still set the fields
+        // they take so old serialized configs round-trip cleanly.
         let config = MemoryConfig::new()
             .with_max_jobs(5_000)
             .with_auto_cleanup(false)

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -145,22 +145,23 @@ impl PostgresStorage {
             })
     }
 
-    /// Helper method to detect if a database error is schema-related
+    /// Detect whether a database error is "schema is missing" — i.e.
+    /// the kind that auto-migrate should handle by re-running
+    /// `install.sql`.
     ///
-    /// This method analyzes database errors to determine if they're caused by
-    /// missing schema or tables, which indicates migrations need to be run.
+    /// SQLSTATE alone is sufficient. The previous implementation also
+    /// matched the error message text (`"does not exist"` etc.), but
+    /// that's locale-dependent: a Postgres server with
+    /// `lc_messages = de_DE.UTF-8` returns "Existiert nicht" and the
+    /// string fallback silently breaks. Codes 42P01 (undefined_table)
+    /// and 3F000 (invalid_schema_name) are stable across locales and
+    /// already cover the scenarios `handle_schema_error` cares about.
     pub(crate) fn is_schema_error(error: &sqlx::Error) -> bool {
         match error {
             sqlx::Error::Database(db_err) => {
                 let code = db_err.code().unwrap_or_default();
-                let message = db_err.message().to_lowercase();
-
-                // PostgreSQL error codes for missing schema/table
-                code == "42P01" || // undefined_table
-                code == "3F000" || // invalid_schema_name
-                message.contains("does not exist") ||
-                message.contains("relation") && message.contains("does not exist") ||
-                message.contains("schema") && message.contains("does not exist")
+                code == "42P01" /* undefined_table */
+                    || code == "3F000" /* invalid_schema_name */
             }
             _ => false,
         }

--- a/tests/config_panic_fix_test.rs
+++ b/tests/config_panic_fix_test.rs
@@ -6,8 +6,11 @@
 use qml_rs::storage::MemoryConfig;
 
 #[test]
+#[allow(deprecated)]
 fn test_memory_config_no_panic() {
-    // Test Memory config (should always work)
+    // Test Memory config (should always work). `auto_cleanup` is a
+    // deprecated no-op but the field must still default (back-compat
+    // serde round-trip).
     let memory_config = MemoryConfig::default();
     assert_eq!(memory_config.max_jobs, Some(10_000));
     assert!(memory_config.auto_cleanup);

--- a/tests/dashboard_shutdown_test.rs
+++ b/tests/dashboard_shutdown_test.rs
@@ -38,6 +38,8 @@ async fn shutdown_token_fires_returns_start_cleanly() {
         auth: None,
         #[cfg(feature = "metrics")]
         metrics: None,
+        #[cfg(feature = "metrics")]
+        metrics_skip_auth: false,
     };
 
     let server = Arc::new(DashboardServer::new(storage, config));
@@ -74,6 +76,8 @@ async fn external_cancellation_token_propagates() {
         auth: None,
         #[cfg(feature = "metrics")]
         metrics: None,
+        #[cfg(feature = "metrics")]
+        metrics_skip_auth: false,
     };
 
     let server = Arc::new(DashboardServer::new(storage, config));
@@ -149,6 +153,8 @@ async fn shutdown_returns_even_when_periodic_task_is_wedged() {
         auth: None,
         #[cfg(feature = "metrics")]
         metrics: None,
+        #[cfg(feature = "metrics")]
+        metrics_skip_auth: false,
     };
 
     let server = Arc::new(DashboardServer::new(storage, config));

--- a/tests/storage_integration_tests.rs
+++ b/tests/storage_integration_tests.rs
@@ -175,8 +175,15 @@ async fn test_concurrent_storage_access() {
     }
 }
 
-/// Test storage configuration serialization round-trip
+/// Test storage configuration serialization round-trip.
+///
+/// `auto_cleanup` is now a deprecated no-op (`MemoryStorage` never read
+/// it; cleanup is owned by `CleanupWorker`). The round-trip still has
+/// to preserve the field so old serialized configs deserialize without
+/// data loss — that's why we keep exercising it here, behind
+/// `allow(deprecated)`.
 #[tokio::test]
+#[allow(deprecated)]
 async fn test_config_serialization_roundtrip() {
     // Test Memory config
     let memory_config = StorageConfig::Memory(


### PR DESCRIPTION
Final cleanup batch from the principal-engineer review. Five small contained changes; bundled together because each is well under a one-PR threshold. **+283 / −83 over 12 files.**

After this lands, every actionable item from the original review is closed.

## Changes

**N6 — dead `MemoryConfig` fields.** `auto_cleanup` and `cleanup_interval` were never observed by `MemoryStorage` (final-state expiration has been owned by `CleanupWorker` since the early redesign). Marked the fields and their builders `#[deprecated]` rather than removing outright — the struct still has to round-trip through serde so old serialized configs deserialize without data loss. In-tree callers (two examples) drop the no-op `with_auto_cleanup(true)` call; the round-trip test gets `#[allow(deprecated)]`.

**N2 — locale-dependent string matching in `is_schema_error`.** The auto-migrate path accepted schema-missing errors via either SQLSTATE `42P01` / `3F000` *or* message contents like `"does not exist"`. The string fallback breaks under any non-English `lc_messages` (German "Existiert nicht", Spanish "no existe", etc.). SQLSTATE alone is locale-independent and already covers the path's needs.

**N3 — replace hand-rolled crypto with crates.** `dashboard/auth.rs` carried 25 lines of bespoke Base64 decoding and 15 lines of XOR-fold constant-time comparison. Swapped both for audited implementations: `base64 = "0.22"` and `subtle = "2.6"`. Both gated behind the existing `dashboard` feature so default builds don't pull them in. The 15 dashboard auth tests pass unchanged.

**I7 — direct `Processing → AwaitingRetry` transition.** `JobProcessor::handle_job_retry` used to do a fragile two-step `Processing → Failed → AwaitingRetry`, with the intermediate `Failed` an artifact that never hit storage. A panic between the two `set_state` calls would leave the in-memory job indistinguishable from a real terminal failure. Added the direct transition to `can_transition_to` and collapsed the retry path to one `set_state`. The state-change hook still fires once with the original pre-retry state.

**N1 — opt-in auth bypass for `/metrics`.** Prometheus scrapers can't speak Basic/Bearer; previously operators had to scrape via a sidecar. Added `DashboardConfig::metrics_skip_auth: bool` (default false, gated on `metrics` feature). When true, the `/metrics` route is mounted *outside* the auth middleware so scrapers can reach it without credentials; every other route still demands them. Two new tests drive the full router via `tower::ServiceExt::oneshot` to assert both shapes.

## What's deliberately not in this PR

**N5 — `Failed → Enqueued` "manual retry" shortcut.** The reviewer flagged this as state-machine looseness. We use it from `DashboardService::retry_job`, which is now CAS-protected via `MonitoringApi::update_if_state` (batch 1). Pure-state-machine purity would require the dashboard to push through `Failed → AwaitingRetry → Enqueued` instead — two transitions, two writes, more failure modes. Keeping the direct shortcut for human-triggered retries; the CAS gate already prevents the original race concern.

## Breaking changes (callout for downstream)

* **`DashboardConfig` got a new field** (`metrics_skip_auth`, gated on the `metrics` feature). Anyone constructing the struct via field literal needs to add it; `Default::default()` callers are unaffected.
* **Two new optional dependencies** (`base64`, `subtle`) pulled in by the `dashboard` feature. No effect on default builds.
* **`MemoryConfig::auto_cleanup` / `cleanup_interval` fields and their `with_*` builders are `#[deprecated]`.** They still round-trip through serde for back-compat; calling them just emits a deprecation warning.

## Test plan

- [x] `cargo build --all-features --all-targets` clean.
- [x] `cargo fmt` applied.
- [x] Full suite single-threaded with Redis + Postgres up under `--all-features`: **179 passing, 0 failed**.

## Review backlog status

After this PR, every substantive item from the original principal-engineer review is closed across batches 1–4:

* Batch 1 (#23) — Redis correctness, Postgres JSON-paths, scheduler atomicity, dashboard shutdown, error chains, CAS, `list` typing.
* Batch 2 (#24) — Postgres hot-path indexes, `qml_locks` sweeper, `StorageError` consolidation, per-queue Redis ZSETs.
* Batch 3 (#25) — `Storage` trait split + `StorageInstance` retirement.
* Batch 4 (this PR) — N1, N2, N3, N6, I7 polish.

Only `N5` deliberately skipped, with reasoning in this PR description.